### PR TITLE
feat: match scraped classes to Notion Conteúdo pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 FIAP_USERNAME=your_username
 FIAP_PASSWORD=your_password
+
+NOTION_TOKEN=your_notion_token
+NOTION_PHASES_DB_ID=your_notion_phases_db_id

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ downloads
 
 #ai
 .claude
+.playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,37 +22,43 @@ No test runner is configured yet. Node.js >= 24.x and npm >= 11.x required.
 
 ## Architecture
 
-This is a TypeScript + Puppeteer web scraper that authenticates on the FIAP course platform, extracts course structure, and (eventually) downloads/uploads materials to Notion.
+This is a TypeScript + Puppeteer web scraper that authenticates on the FIAP course platform, extracts course structure, matches classes to Notion, and (next) uploads HLS videos.
 
 **Execution flow** (`src/index.ts`):
 1. Launch Puppeteer browser
 2. `auth/` — Log in with credentials from `.env`, navigate to course page
-3. `phases/` — Scrape available phases, identify the active one
-4. `subjects/` — Scrape subjects and their classes within the active phase
-5. (Planned) Download PDFs and videos, upload to Notion
+3. `phases/` — Scrape all available phases
+4. `cli/` — Interactive prompt: user selects a phase; loops until exit
+5. `subjects/` — Scrape subjects and classes for the selected phase
+6. `notion/` — Resolve Conteúdo DB collection ID, match `ClassItem.title` → Notion page ID
+7. (Next) Extract HLS video URLs from each class's `contentUrl`, upload to Notion
 
 **Module layout**:
 - `src/auth/` — Login and course page access verification
-- `src/phases/` — Extract phase list and active phase from DOM
+- `src/phases/` — Scrape phase list; `getPhaseDisplayTitle()` builds the human-readable label from `Phase.topic`
 - `src/subjects/` — Complex DOM evaluation to build `Subject → ClassItem[]` hierarchy
+- `src/notion/` — Resolve Notion collection IDs and match scraped classes to Conteúdo entries
+- `src/cli/` — Interactive phase selector using `@inquirer/prompts`
 - `src/constants/` — FIAP URLs (single source of truth)
 
 **Key types** (in each module's `types.ts`):
-- `Phase`: title, isActive, index, courseId
+- `Phase`: title, topic (from "Welcome to \<topic\>" marker), isActive, index, courseId
 - `Subject`: title, classes (ClassItem[])
 - `ClassItem`: title, contentUrl, pdfUrl, progress
 
-**DOM scraping pattern**: `phases/` uses `page.$$(selector)` + `element.evaluate()` for per-element extraction; `subjects/` uses a single `page.evaluate()` call running client-side JS against the full document.
+**DOM scraping pattern**: `phases/` uses `page.$$eval()` for batch extraction; `subjects/` uses a single `page.evaluate()` call running client-side JS against the full document.
 
 ## Environment
 
-Copy `.env.example` to `.env` and fill in FIAP credentials:
+Copy `.env.example` to `.env`:
 ```
 FIAP_USERNAME=...
 FIAP_PASSWORD=...
+NOTION_TOKEN=...           # Notion integration token
+NOTION_PHASES_DB_ID=...    # Page ID of the top-level Fases database (not the collection ID — resolved internally)
 ```
 
-Credentials are validated at runtime — the scraper will fail fast if they are missing.
+All four vars are validated at startup — the scraper will fail fast if any are missing.
 
 ## FIAP Course Page Structure
 
@@ -68,7 +74,11 @@ The course page DOM hierarchy relevant to scraping:
     - `.t-conteudo-atividades` — marks activity items (assignments/quizzes) — **skipped**
     - `.progresso-conteudo[data-porcentagem]` — completion percentage
 
-Phase active detection: completed courses have no reliable CSS/ARIA active marker — fallback to `phases[0]` (FIAP lists phases newest-first). Items starting with `"Welcome"` or `"Atividade:"` are skipped (section headers, not real content).
+Phase active detection: completed courses have no reliable CSS/ARIA active marker — `isActive` is best-effort and only used to pre-select the default in the CLI prompt. Phase selection is always user-driven.
+
+Items skipped during subject scraping (section headers, not real content):
+- `is-marcador` items starting with `"Welcome"` or `"Atividade:"`
+- Regular items titled `"Conteúdos externos"`
 
 ## Notion Workspace Structure
 
@@ -89,3 +99,4 @@ Inline databases (Disciplinas, Conteúdo) have unique IDs per Fase page and are 
 - Strict TypeScript (`tsconfig.json` has `strict: true`)
 - Imports resolve from `src/` as base URL (e.g., `import { FIAP_URLS } from 'constants'`)
 - Prettier enforced: single quotes, semicolons, trailing commas, 100-char print width
+- `ora` is pinned to **v5** — v6+ dropped CommonJS support and will break this project (`"module": "commonjs"` in `tsconfig.json`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development (runs TypeScript directly)
+npm run dev
+
+# Build TypeScript to dist/
+npm run build
+
+# Build then run compiled output
+npm run build:start
+
+# Format code
+npm run format
+```
+
+No test runner is configured yet. Node.js >= 24.x and npm >= 11.x required.
+
+## Architecture
+
+This is a TypeScript + Puppeteer web scraper that authenticates on the FIAP course platform, extracts course structure, and (eventually) downloads/uploads materials to Notion.
+
+**Execution flow** (`src/index.ts`):
+1. Launch Puppeteer browser
+2. `auth/` — Log in with credentials from `.env`, navigate to course page
+3. `phases/` — Scrape available phases, identify the active one
+4. `subjects/` — Scrape subjects and their classes within the active phase
+5. (Planned) Download PDFs and videos, upload to Notion
+
+**Module layout**:
+- `src/auth/` — Login and course page access verification
+- `src/phases/` — Extract phase list and active phase from DOM
+- `src/subjects/` — Complex DOM evaluation to build `Subject → ClassItem[]` hierarchy
+- `src/constants/` — FIAP URLs (single source of truth)
+
+**Key types** (in each module's `types.ts`):
+- `Phase`: title, isActive, index, courseId
+- `Subject`: title, classes (ClassItem[])
+- `ClassItem`: title, contentUrl, pdfUrl, progress
+
+**DOM scraping pattern**: `phases/` uses `page.$$(selector)` + `element.evaluate()` for per-element extraction; `subjects/` uses a single `page.evaluate()` call running client-side JS against the full document.
+
+## Environment
+
+Copy `.env.example` to `.env` and fill in FIAP credentials:
+```
+FIAP_USERNAME=...
+FIAP_PASSWORD=...
+```
+
+Credentials are validated at runtime — the scraper will fail fast if they are missing.
+
+## Code Conventions
+
+- Strict TypeScript (`tsconfig.json` has `strict: true`)
+- Imports resolve from `src/` as base URL (e.g., `import { FIAP_URLS } from 'constants'`)
+- Prettier enforced: single quotes, semicolons, trailing commas, 100-char print width

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,36 @@ FIAP_PASSWORD=...
 
 Credentials are validated at runtime — the scraper will fail fast if they are missing.
 
+## FIAP Course Page Structure
+
+The course page DOM hierarchy relevant to scraping:
+- `.conteudo-digital-disciplina-content` — one per phase
+  - `.conteudo-digital-disciplina-fase[data-fase="<courseId>"]` — phase header; holds title and ID
+- `.conteudo-digital-list` — sibling of the above; contains all subjects and classes for that phase
+  - `.conteudo-digital-item.is-marcador` — subject header row
+  - `.conteudo-digital-item` (without `is-marcador`) — class row under the preceding subject
+    - `.conteudo-digital-txt-name` — title
+    - `.t-conteudo-digital` — link to the video/content page (`contentUrl`)
+    - `.t-conteudo-pdf` — link to the PDF (`pdfUrl`)
+    - `.t-conteudo-atividades` — marks activity items (assignments/quizzes) — **skipped**
+    - `.progresso-conteudo[data-porcentagem]` — completion percentage
+
+Phase active detection: completed courses have no reliable CSS/ARIA active marker — fallback to `phases[0]` (FIAP lists phases newest-first). Items starting with `"Welcome"` or `"Atividade:"` are skipped (section headers, not real content).
+
+## Notion Workspace Structure
+
+```
+Fases DB (NOTION_PHASES_DB_ID)          ← top-level, one row per phase
+  └── Fase N                            ← matched by "Fase N" prefix (FIAP full titles include a subtitle after " - ")
+        ├── Disciplinas DB (inline)     ← not used yet
+        └── Conteúdo DB (inline)        ← one row per class, matched by ClassItem.title
+              schema: Name (title), Disciplina (relation), Status, Docs (file), Período (date)
+```
+
+**Notion SDK v5.15.0 quirk**: `databases.query` was removed. Use `dataSources.query({ data_source_id })` where `data_source_id` is the **collection ID**, not the database page ID. Bridge via `databases.retrieve(pageId).data_sources[0].id` — see `resolveDataSourceId()` in `src/notion/index.ts`.
+
+Inline databases (Disciplinas, Conteúdo) have unique IDs per Fase page and are discovered at runtime by listing child blocks (`blocks.children.list`) and filtering for `child_database` blocks by title.
+
 ## Code Conventions
 
 - Strict TypeScript (`tsconfig.json` has `strict: true`)

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ A work in progress... :hourglass_flowing_sand:
 
 ## Description
 
-This project is designed to automate the process of downloading study materials (PDFs and videos) from my FIAP course subjects and uploading them into my personal Notion. The main goal is to streamline the workflow of storing course content for later reference and organization.
+This project automates syncing study materials from my FIAP course into my personal Notion workspace. It scrapes the course platform and uploads video content to the corresponding Notion pages, keeping course content organized without manual effort.
 
 The scraper will:
 
 1. Authenticate on the FIAP course page.
-2. Extract PDFs and video links for each class.
-3. Download the PDFs.
-4. Download and convert the video files.
-5. Upload the PDFs and videos to Notion.
+2. Detect the active phase and extract its subjects and classes.
+3. Match each class to its corresponding page in the Notion Conteúdo database.
+4. Extract HLS video URLs for each class.
+5. Upload the videos to Notion.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,59 @@ The scraper will:
 4. Extract HLS video URLs for each class.
 5. Upload the videos to Notion.
 
+## How It Works
+
+```mermaid
+sequenceDiagram
+    actor user as User
+    participant scraper as Scraper
+    participant fiap as FIAP Platform
+    participant notion as Notion
+
+    user->>scraper: npm run dev
+    scraper->>fiap: Login + fetch phases
+    fiap-->>scraper: Phase list
+    scraper->>user: Select a phase
+    user-->>scraper: Fase N
+
+    scraper->>fiap: Scrape subjects + classes
+    fiap-->>scraper: ClassItem[]
+
+    scraper->>notion: Query Conteúdo DB
+    notion-->>scraper: Existing entries
+    scraper->>scraper: Match titles → page IDs
+
+    scraper->>fiap: Extract HLS video URLs
+    fiap-->>scraper: Video URLs
+    scraper->>notion: Upload videos
+```
+
+## Notion Workspace Structure
+
+> **Note:** This project is tailored to a specific Notion workspace structure. The scraper expects the following hierarchy to exist before running — pages and databases are not created automatically.
+
+```mermaid
+graph TD
+    fases_db[(Fases DB)] --> fase_n[Fase N]
+    fase_n --> disciplinas_db[(Disciplinas DB)]
+    fase_n --> conteudo_db[(Conteúdo DB)]
+    disciplinas_db --> subject[Subject]
+    conteudo_db --> aula[Class]
+    subject -. relation .-> aula
+```
+
+Each **Fase** page contains two inline databases:
+- **Disciplinas** — one row per subject, with a relation to Conteúdo
+- **Conteúdo** — one row per class; this is what the scraper matches against and uploads to
+
+## Technologies
+
+- **[TypeScript](https://www.typescriptlang.org/)** — type-safe JavaScript
+- **[Puppeteer](https://pptr.dev/)** — headless browser for scraping the FIAP course platform
+- **[Notion SDK](https://github.com/makenotion/notion-sdk-js)** — querying and updating the Notion workspace
+- **[@inquirer/prompts](https://github.com/SBoudrias/Inquirer.js)** — interactive CLI prompts
+- **[ora](https://github.com/sindresorhus/ora)** — terminal spinners for async feedback
+
 ## Prerequisites
 
 Make sure you have the following installed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@notionhq/client": "^5.15.0",
         "dotenv": "^17.3.1",
         "puppeteer": "^24.40.0"
       },
@@ -19,7 +20,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": "lts",
+        "node": ">=24.0.0",
         "npm": ">=11.0.0"
       }
     },
@@ -83,6 +84,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.15.0.tgz",
+      "integrity": "sha512-boQ+zMmTu/HRfPajynYjlXkytkmn0rUgD0FJrbMaz6n1WC6HPxe2Lgn/Ay/VEA2j2dMzB1Hpnhtrtkz4Q1I/rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@inquirer/prompts": "^8.3.2",
         "@notionhq/client": "^5.15.0",
         "dotenv": "^17.3.1",
+        "ora": "^5.4.1",
         "puppeteer": "^24.40.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "@types/ora": "^3.1.0",
         "prettier": "^3.8.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
@@ -56,6 +59,334 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
+      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
+      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
+      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
+      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
+      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/external-editor": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
+      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
+      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
+      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
+      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
+      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
+      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
+      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.2",
+        "@inquirer/confirm": "^6.0.10",
+        "@inquirer/editor": "^5.0.10",
+        "@inquirer/expand": "^5.0.10",
+        "@inquirer/input": "^5.0.10",
+        "@inquirer/number": "^4.0.10",
+        "@inquirer/password": "^5.0.10",
+        "@inquirer/rawlist": "^5.2.6",
+        "@inquirer/search": "^4.1.6",
+        "@inquirer/select": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
+      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
+      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
+      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
+      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -158,6 +489,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ora": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ora/-/ora-3.1.0.tgz",
+      "integrity": "sha512-4e15N42qhHRlxyP5SpX9fK3q4tXvEkdmGdof2DZ0mqPu7glrNT8cs9bbI73NhwEGApq1TSXhs2aFmn19VCTwCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yauzl": {
@@ -354,6 +695,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
@@ -361,6 +722,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -380,6 +776,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
@@ -391,6 +809,39 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -405,6 +856,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -481,6 +941,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/degenerator": {
@@ -652,6 +1124,30 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -699,6 +1195,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -725,6 +1230,42 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -739,6 +1280,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -761,6 +1308,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-tokens": {
@@ -790,6 +1358,22 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -806,6 +1390,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -817,6 +1410,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -834,6 +1436,44 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -1006,6 +1646,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1023,6 +1677,51 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -1033,6 +1732,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/smart-buffer": {
@@ -1094,6 +1805,15 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1115,6 +1835,18 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -1241,12 +1973,27 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@notionhq/client": "^5.15.0",
     "dotenv": "^17.3.1",
     "puppeteer": "^24.40.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,12 +13,15 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.3.2",
     "@notionhq/client": "^5.15.0",
     "dotenv": "^17.3.1",
+    "ora": "^5.4.1",
     "puppeteer": "^24.40.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/ora": "^3.1.0",
     "prettier": "^3.8.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -13,13 +13,7 @@ export async function loginToFIAP(page: Page, { username, password }: LoginCrede
   await Promise.all([
     page.click('#loginbtn-plataforma'),
     page.waitForNavigation({ waitUntil: 'networkidle0' }),
-  ])
-    .then(() => {
-      console.log('Successfully logged in');
-    })
-    .catch((e) => {
-      console.error('Failed to login:', e);
-    });
+  ]);
 }
 
 export async function ensureAccessToCoursePage(page: Page) {
@@ -32,5 +26,4 @@ export async function ensureAccessToCoursePage(page: Page) {
     throw new Error('Failed to access course page');
   }
 
-  console.log('Successfully accessing the course page');
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,24 @@
+import { select, Separator } from '@inquirer/prompts';
+import { Phase } from '../phases/types';
+import { getPhaseDisplayTitle } from '../phases';
+
+/** Returns the selected Phase, or null if the user chose to exit. */
+export async function selectPhase(phases: Phase[]): Promise<Phase | null> {
+  const defaultPhase = phases.find((p) => p.isActive) ?? phases[0];
+
+  return select<Phase | null>({
+    message: 'Select a phase to sync:',
+    choices: [
+      ...phases.map((phase) => {
+        const label = getPhaseDisplayTitle(phase);
+        return {
+          name: phase.isActive ? `${label} (active)` : label,
+          value: phase as Phase | null,
+        };
+      }),
+      new Separator(),
+      { name: 'Exit', value: null },
+    ],
+    default: defaultPhase,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,21 @@
 import 'dotenv/config';
 import puppeteer from 'puppeteer';
+import { Client } from '@notionhq/client';
 import { loginToFIAP, ensureAccessToCoursePage } from './auth';
 import { getPhaseList, getActivePhase } from './phases';
 import { getSubjectList } from './subjects';
+import { getPhaseCollections, matchClassesToNotion } from './notion';
 
 async function main() {
-  const browser = await puppeteer.launch({ headless: false }); // Change to true to run in headless mode
-  const page = await browser.newPage();
-
   if (!process.env.FIAP_USERNAME || !process.env.FIAP_PASSWORD) {
     throw new Error('Please provide FIAP_USERNAME and FIAP_PASSWORD in .env file');
   }
+  if (!process.env.NOTION_TOKEN || !process.env.NOTION_PHASES_DB_ID) {
+    throw new Error('Please provide NOTION_TOKEN and NOTION_PHASES_DB_ID in .env file');
+  }
+
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
 
   await loginToFIAP(page, {
     username: process.env.FIAP_USERNAME,
@@ -29,6 +34,16 @@ async function main() {
   console.log('Subjects in active phase:', JSON.stringify(subjects, null, 2));
 
   await browser.close();
+
+  const notion = new Client({ auth: process.env.NOTION_TOKEN });
+  const collections = await getPhaseCollections(notion, activePhase);
+  console.log(`Found Conteúdo DB: ${collections.conteudoDbId}`);
+
+  const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects, activePhase.title);
+  console.log(`Matched ${classMap.size} classes to Notion pages`);
+  if (unmatched.length) {
+    console.warn(`Unmatched classes (${unmatched.length}):`, unmatched);
+  }
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,48 +16,51 @@ async function main() {
     throw new Error('Please provide NOTION_TOKEN and NOTION_PHASES_DB_ID in .env file');
   }
 
-  let spinner = ora('[scraper] Logging in to FIAP...').start();
   const browser = await puppeteer.launch({ headless: true });
-  const page = await browser.newPage();
-  await loginToFIAP(page, {
-    username: process.env.FIAP_USERNAME,
-    password: process.env.FIAP_PASSWORD,
-  });
-  spinner.succeed('[scraper] Logged in');
 
-  spinner = ora('[scraper] Loading course page...').start();
-  await ensureAccessToCoursePage(page);
-  spinner.succeed('[scraper] Course page ready');
+  try {
+    let spinner = ora('[scraper] Logging in to FIAP...').start();
+    const page = await browser.newPage();
+    await loginToFIAP(page, {
+      username: process.env.FIAP_USERNAME,
+      password: process.env.FIAP_PASSWORD,
+    });
+    spinner.succeed('[scraper] Logged in');
 
-  spinner = ora('[scraper] Fetching phase list...').start();
-  const phases = await getPhaseList(page);
-  spinner.succeed(`[scraper] Found ${phases.length} phases`);
+    spinner = ora('[scraper] Loading course page...').start();
+    await ensureAccessToCoursePage(page);
+    spinner.succeed('[scraper] Course page ready');
 
-  const notion = new Client({ auth: process.env.NOTION_TOKEN });
+    spinner = ora('[scraper] Fetching phase list...').start();
+    const phases = await getPhaseList(page);
+    spinner.succeed(`[scraper] Found ${phases.length} phases`);
 
-  while (true) {
-    console.log();
-    const selectedPhase = await selectPhase(phases);
-    if (!selectedPhase) break;
+    const notion = new Client({ auth: process.env.NOTION_TOKEN });
 
-    const displayTitle = getPhaseDisplayTitle(selectedPhase);
+    while (true) {
+      console.log();
+      const selectedPhase = await selectPhase(phases);
+      if (!selectedPhase) break;
 
-    spinner = ora(`[scraper] Scraping subjects for ${displayTitle}...`).start();
-    const subjects = await getSubjectList(page, selectedPhase);
-    const classCount = subjects.reduce((sum, s) => sum + s.classes.length, 0);
-    spinner.succeed(`[scraper] Found ${subjects.length} subjects, ${classCount} classes`);
+      const displayTitle = getPhaseDisplayTitle(selectedPhase);
 
-    spinner = ora('[notion] Matching classes...').start();
-    const collections = await getPhaseCollections(notion, selectedPhase);
-    const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects);
-    spinner.succeed(`[notion] Matched ${classMap.size}/${classCount} classes`);
+      spinner = ora(`[scraper] Scraping subjects for ${displayTitle}...`).start();
+      const subjects = await getSubjectList(page, selectedPhase);
+      const classCount = subjects.reduce((sum, s) => sum + s.classes.length, 0);
+      spinner.succeed(`[scraper] Found ${subjects.length} subjects, ${classCount} classes`);
 
-    if (unmatched.length) {
-      console.warn(`⚠️  [notion] Unmatched (${unmatched.length}):`, unmatched);
+      spinner = ora('[notion] Matching classes...').start();
+      const collections = await getPhaseCollections(notion, selectedPhase);
+      const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects);
+      spinner.succeed(`[notion] Matched ${classMap.size}/${classCount} classes`);
+
+      if (unmatched.length) {
+        console.warn(`⚠️  [notion] Unmatched (${unmatched.length}):`, unmatched);
+      }
     }
+  } finally {
+    await browser.close();
   }
-
-  await browser.close();
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import 'dotenv/config';
+import ora from 'ora';
 import puppeteer from 'puppeteer';
 import { Client } from '@notionhq/client';
 import { loginToFIAP, ensureAccessToCoursePage } from './auth';
-import { getPhaseList, getActivePhase } from './phases';
+import { getPhaseList, getPhaseDisplayTitle } from './phases';
 import { getSubjectList } from './subjects';
 import { getPhaseCollections, matchClassesToNotion } from './notion';
+import { selectPhase } from './cli';
 
 async function main() {
   if (!process.env.FIAP_USERNAME || !process.env.FIAP_PASSWORD) {
@@ -14,36 +16,48 @@ async function main() {
     throw new Error('Please provide NOTION_TOKEN and NOTION_PHASES_DB_ID in .env file');
   }
 
+  let spinner = ora('[scraper] Logging in to FIAP...').start();
   const browser = await puppeteer.launch({ headless: true });
   const page = await browser.newPage();
-
   await loginToFIAP(page, {
     username: process.env.FIAP_USERNAME,
     password: process.env.FIAP_PASSWORD,
   });
+  spinner.succeed('[scraper] Logged in');
 
+  spinner = ora('[scraper] Loading course page...').start();
   await ensureAccessToCoursePage(page);
+  spinner.succeed('[scraper] Course page ready');
 
+  spinner = ora('[scraper] Fetching phase list...').start();
   const phases = await getPhaseList(page);
-  console.log('Phases:', phases);
-
-  const activePhase = getActivePhase(phases);
-  console.log('Active phase:', activePhase);
-
-  const subjects = await getSubjectList(page, activePhase);
-  console.log('Subjects in active phase:', JSON.stringify(subjects, null, 2));
-
-  await browser.close();
+  spinner.succeed(`[scraper] Found ${phases.length} phases`);
 
   const notion = new Client({ auth: process.env.NOTION_TOKEN });
-  const collections = await getPhaseCollections(notion, activePhase);
-  console.log(`Found Conteúdo DB: ${collections.conteudoDbId}`);
 
-  const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects, activePhase.title);
-  console.log(`Matched ${classMap.size} classes to Notion pages`);
-  if (unmatched.length) {
-    console.warn(`Unmatched classes (${unmatched.length}):`, unmatched);
+  while (true) {
+    console.log();
+    const selectedPhase = await selectPhase(phases);
+    if (!selectedPhase) break;
+
+    const displayTitle = getPhaseDisplayTitle(selectedPhase);
+
+    spinner = ora(`[scraper] Scraping subjects for ${displayTitle}...`).start();
+    const subjects = await getSubjectList(page, selectedPhase);
+    const classCount = subjects.reduce((sum, s) => sum + s.classes.length, 0);
+    spinner.succeed(`[scraper] Found ${subjects.length} subjects, ${classCount} classes`);
+
+    spinner = ora('[notion] Matching classes...').start();
+    const collections = await getPhaseCollections(notion, selectedPhase);
+    const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects);
+    spinner.succeed(`[notion] Matched ${classMap.size}/${classCount} classes`);
+
+    if (unmatched.length) {
+      console.warn(`⚠️  [notion] Unmatched (${unmatched.length}):`, unmatched);
+    }
   }
+
+  await browser.close();
 }
 
 main().catch((error) => {

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -13,8 +13,10 @@ import { ClassNotionMap, NotionMatchResult, PhaseCollections } from './types';
  * databases.retrieve bridges the two via its data_sources[] field.
  */
 async function resolveDataSourceId(notion: Client, databasePageId: string): Promise<string> {
-  const db = await (notion.databases.retrieve as Function)({ database_id: databasePageId });
-  const dataSource = (db.data_sources as Array<{ id: string }>)?.[0];
+  const db = (await notion.databases.retrieve({
+    database_id: databasePageId,
+  })) as unknown as { data_sources?: Array<{ id: string }> };
+  const dataSource = db.data_sources?.[0];
   if (!dataSource?.id) {
     throw new Error(`Could not resolve data source ID for database page: ${databasePageId}`);
   }
@@ -51,12 +53,23 @@ export async function getPhaseCollections(
 
   const fasePageId = response.results[0].id;
 
-  // Inline databases appear as child_database blocks on the Fase page
-  const blocks = await notion.blocks.children.list({ block_id: fasePageId });
-  const conteudoBlock = (blocks.results as BlockObjectResponse[]).find(
-    (block): block is ChildDatabaseBlockObjectResponse =>
-      block.type === 'child_database' && block.child_database.title === 'Conteúdo',
-  );
+  // Inline databases appear as child_database blocks on the Fase page — paginate to avoid missing them
+  let blockCursor: string | undefined;
+  let conteudoBlock: ChildDatabaseBlockObjectResponse | undefined;
+  do {
+    const blocks = await notion.blocks.children.list({
+      block_id: fasePageId,
+      start_cursor: blockCursor,
+    });
+    conteudoBlock = (blocks.results as BlockObjectResponse[]).find(
+      (block): block is ChildDatabaseBlockObjectResponse =>
+        block.type === 'child_database' && block.child_database.title === 'Conteúdo',
+    );
+    blockCursor =
+      !conteudoBlock && blocks.has_more && blocks.next_cursor
+        ? blocks.next_cursor
+        : undefined;
+  } while (!conteudoBlock && blockCursor);
 
   if (!conteudoBlock) {
     throw new Error(
@@ -67,7 +80,7 @@ export async function getPhaseCollections(
   // Resolve the inline database's block ID to its data source ID
   const conteudoDataSourceId = await resolveDataSourceId(notion, conteudoBlock.id);
 
-  return { fasePageId, conteudoDbId: conteudoDataSourceId };
+  return { fasePageId, conteudoDataSourceId };
 }
 
 /**
@@ -87,7 +100,7 @@ export async function matchClassesToNotion(
   let cursor: string | undefined;
   do {
     const response = await notion.dataSources.query({
-      data_source_id: collections.conteudoDbId,
+      data_source_id: collections.conteudoDataSourceId,
       start_cursor: cursor,
     });
 
@@ -111,7 +124,7 @@ export async function matchClassesToNotion(
 
   for (const subject of subjects) {
     for (const classItem of subject.classes) {
-      const normalizedTitle = classItem.title.replace(/\s+/g, ' ');
+      const normalizedTitle = classItem.title.trim().replace(/\s+/g, ' ');
       const notionPageId = notionTitleMap.get(normalizedTitle.toLowerCase());
       if (notionPageId) {
         classMap.set(classItem.title, notionPageId);

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -1,0 +1,129 @@
+import { Client, isFullPage } from '@notionhq/client';
+import {
+  BlockObjectResponse,
+  ChildDatabaseBlockObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import { Phase } from '../phases/types';
+import { Subject } from '../subjects/types';
+import { ClassNotionMap, NotionMatchResult, PhaseCollections } from './types';
+
+/**
+ * Resolves a database page ID to its underlying data source (collection) ID.
+ * In SDK v5.15.0, dataSources.query requires the collection ID, not the page ID.
+ * databases.retrieve bridges the two via its data_sources[] field.
+ */
+async function resolveDataSourceId(notion: Client, databasePageId: string): Promise<string> {
+  const db = await (notion.databases.retrieve as Function)({ database_id: databasePageId });
+  const dataSource = (db.data_sources as Array<{ id: string }>)?.[0];
+  if (!dataSource?.id) {
+    throw new Error(`Could not resolve data source ID for database page: ${databasePageId}`);
+  }
+  return dataSource.id;
+}
+
+/**
+ * Finds the Notion Fase page matching the active phase title, then discovers
+ * the Conteúdo inline database and resolves its data source ID.
+ *
+ * Requires NOTION_PHASES_DB_ID env var pointing to the top-level Fases database page ID.
+ */
+export async function getPhaseCollections(
+  notion: Client,
+  activePhase: Phase,
+): Promise<PhaseCollections> {
+  const phasesDbPageId = process.env.NOTION_PHASES_DB_ID!;
+  const phasesDataSourceId = await resolveDataSourceId(notion, phasesDbPageId);
+
+  // FIAP titles are "Fase 5 - Qualidade e Deploy Ágil"; Notion pages are titled "Fase 5".
+  // Extract the "Fase N" prefix for the lookup.
+  const notionPhaseTitle = activePhase.title.split(' - ')[0].trim();
+
+  const response = await notion.dataSources.query({
+    data_source_id: phasesDataSourceId,
+    filter: { property: 'Name', title: { equals: notionPhaseTitle } },
+  });
+
+  if (!response.results.length) {
+    throw new Error(
+      `No Notion page found for phase "${notionPhaseTitle}" (scraped title: "${activePhase.title}"). Create it from the Notion template first.`,
+    );
+  }
+
+  const fasePageId = response.results[0].id;
+
+  // Inline databases appear as child_database blocks on the Fase page
+  const blocks = await notion.blocks.children.list({ block_id: fasePageId });
+  const conteudoBlock = (blocks.results as BlockObjectResponse[]).find(
+    (block): block is ChildDatabaseBlockObjectResponse =>
+      block.type === 'child_database' && block.child_database.title === 'Conteúdo',
+  );
+
+  if (!conteudoBlock) {
+    throw new Error(
+      `Could not find "Conteúdo" database on Notion page for phase "${activePhase.title}".`,
+    );
+  }
+
+  // Resolve the inline database's block ID to its data source ID
+  const conteudoDataSourceId = await resolveDataSourceId(notion, conteudoBlock.id);
+
+  return { fasePageId, conteudoDbId: conteudoDataSourceId };
+}
+
+/**
+ * Queries all Conteúdo entries in Notion and matches them against the scraped
+ * subjects/classes by title (case-insensitive). Returns a map of class title
+ * → Notion page ID for matched entries, and a list of unmatched class titles.
+ *
+ * Read-only — makes no changes to Notion.
+ */
+export async function matchClassesToNotion(
+  notion: Client,
+  collections: PhaseCollections,
+  subjects: Subject[],
+  phaseTitle: string,
+): Promise<NotionMatchResult> {
+  // Fetch all Conteúdo entries, paginating if needed
+  const notionTitleMap: Map<string, string> = new Map();
+  let cursor: string | undefined;
+  do {
+    const response = await notion.dataSources.query({
+      data_source_id: collections.conteudoDbId,
+      start_cursor: cursor,
+    });
+
+    for (const page of response.results) {
+      if (!isFullPage(page)) continue;
+      const nameProp = page.properties['Name'];
+      if (nameProp?.type !== 'title') continue;
+      const title = nameProp.title
+        .map((t: { plain_text: string }) => t.plain_text)
+        .join('')
+        .trim()
+        .replace(/\s+/g, ' '); // normalize whitespace
+      if (title) notionTitleMap.set(title.toLowerCase(), page.id);
+    }
+
+    cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+  } while (cursor);
+
+  const classMap: ClassNotionMap = new Map();
+  const unmatched: string[] = [];
+
+  for (const subject of subjects) {
+    for (const classItem of subject.classes) {
+      const normalizedTitle = classItem.title.replace(/\s+/g, ' ');
+      const notionPageId = notionTitleMap.get(normalizedTitle.toLowerCase());
+      if (notionPageId) {
+        classMap.set(classItem.title, notionPageId);
+      } else {
+        console.warn(
+          `[notion] No match for class: "${classItem.title}" (subject: "${subject.title}", phase: "${phaseTitle}")`,
+        );
+        unmatched.push(classItem.title);
+      }
+    }
+  }
+
+  return { classMap, unmatched };
+}

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -81,7 +81,6 @@ export async function matchClassesToNotion(
   notion: Client,
   collections: PhaseCollections,
   subjects: Subject[],
-  phaseTitle: string,
 ): Promise<NotionMatchResult> {
   // Fetch all Conteúdo entries, paginating if needed
   const notionTitleMap: Map<string, string> = new Map();
@@ -117,9 +116,6 @@ export async function matchClassesToNotion(
       if (notionPageId) {
         classMap.set(classItem.title, notionPageId);
       } else {
-        console.warn(
-          `[notion] No match for class: "${classItem.title}" (subject: "${subject.title}", phase: "${phaseTitle}")`,
-        );
         unmatched.push(classItem.title);
       }
     }

--- a/src/notion/types.ts
+++ b/src/notion/types.ts
@@ -1,0 +1,13 @@
+export interface PhaseCollections {
+  fasePageId: string;
+  conteudoDbId: string;
+}
+
+/** Maps a class title (lowercased) to its Notion Conteúdo page ID */
+export type ClassNotionMap = Map<string, string>;
+
+export interface NotionMatchResult {
+  classMap: ClassNotionMap;
+  /** Class titles from the scraper that had no matching Notion page */
+  unmatched: string[];
+}

--- a/src/notion/types.ts
+++ b/src/notion/types.ts
@@ -1,9 +1,9 @@
 export interface PhaseCollections {
   fasePageId: string;
-  conteudoDbId: string;
+  conteudoDataSourceId: string;
 }
 
-/** Maps a class title (lowercased) to its Notion Conteúdo page ID */
+/** Maps a class title (original casing from the scraper) to its Notion Conteúdo page ID */
 export type ClassNotionMap = Map<string, string>;
 
 export interface NotionMatchResult {

--- a/src/phases/index.ts
+++ b/src/phases/index.ts
@@ -1,13 +1,18 @@
 import { Page } from 'puppeteer';
 import { Phase } from './types';
 
+export function getPhaseDisplayTitle(phase: Phase): string {
+  const phaseNumber = phase.title.split(' - ')[0].trim();
+  return phase.topic ? `${phaseNumber} - ${phase.topic}` : phase.title;
+}
+
 export async function getPhaseList(page: Page): Promise<Phase[]> {
   const phaseListSelector = '.conteudo-digital-disciplina-content';
   const phaseList = await page.$$eval(phaseListSelector, (elements: Element[]) => {
     return elements
       .map((element: Element, index: number) => {
         const titleElement = element.querySelector('.conteudo-digital-disciplina-fase');
-        const title = titleElement?.textContent?.trim();
+        const title = titleElement?.textContent?.trim().replace(/\s+/g, ' ');
         const courseId = titleElement?.getAttribute('data-fase');
 
         if (!title?.includes('Fase') || !courseId) {
@@ -21,12 +26,21 @@ export async function getPhaseList(page: Page): Promise<Phase[]> {
           element.getAttribute('aria-expanded') === 'true';
         const isActive = isActiveFromClass || isActiveFromAria;
 
-        return { title, isActive, index, courseId };
+        // Traverse to the sibling .conteudo-digital-list to find the "Welcome to <topic>" marker
+        let listEl = element.nextElementSibling;
+        while (listEl && !listEl.classList.contains('conteudo-digital-list')) {
+          listEl = listEl.nextElementSibling;
+        }
+        const welcomeText = listEl
+          ?.querySelector('.conteudo-digital-item.is-marcador .conteudo-digital-txt-name')
+          ?.textContent?.trim();
+        const topic = welcomeText?.startsWith('Welcome to ')
+          ? welcomeText.slice('Welcome to '.length).trim()
+          : null;
+
+        return { title, topic, isActive, index, courseId };
       })
-      .filter(
-        (phase): phase is { title: string; isActive: boolean; index: number; courseId: string } =>
-          phase !== undefined,
-      );
+      .filter((phase): phase is NonNullable<typeof phase> => phase !== undefined);
   });
 
   if (!phaseList || !phaseList.length) {
@@ -34,15 +48,4 @@ export async function getPhaseList(page: Page): Promise<Phase[]> {
   }
 
   return phaseList;
-}
-
-export function getActivePhase(phases: Phase[]): Phase {
-  const activePhase = phases.find((phase) => phase.isActive);
-  if (activePhase) return activePhase;
-
-  // When no phase has an active CSS/ARIA indicator (e.g. a completed course where
-  // all phases are expanded), fall back to the first phase in the list.
-  // FIAP lists phases newest-first, so index 0 is the most recently active one.
-  console.warn('No CSS-active phase found — defaulting to first phase:', phases[0].title);
-  return phases[0];
 }

--- a/src/phases/index.ts
+++ b/src/phases/index.ts
@@ -12,7 +12,7 @@ export async function getPhaseList(page: Page): Promise<Phase[]> {
     return elements
       .map((element: Element, index: number) => {
         const titleElement = element.querySelector('.conteudo-digital-disciplina-fase');
-        const title = titleElement?.textContent?.trim().replace(/\s+/g, ' ');
+        const title = (titleElement?.textContent ?? '').trim().replace(/\s+/g, ' ');
         const courseId = titleElement?.getAttribute('data-fase');
 
         if (!title?.includes('Fase') || !courseId) {

--- a/src/phases/index.ts
+++ b/src/phases/index.ts
@@ -38,8 +38,11 @@ export async function getPhaseList(page: Page): Promise<Phase[]> {
 
 export function getActivePhase(phases: Phase[]): Phase {
   const activePhase = phases.find((phase) => phase.isActive);
-  if (!activePhase) {
-    throw new Error('No active phase found!');
-  }
-  return activePhase;
+  if (activePhase) return activePhase;
+
+  // When no phase has an active CSS/ARIA indicator (e.g. a completed course where
+  // all phases are expanded), fall back to the first phase in the list.
+  // FIAP lists phases newest-first, so index 0 is the most recently active one.
+  console.warn('No CSS-active phase found — defaulting to first phase:', phases[0].title);
+  return phases[0];
 }

--- a/src/phases/types.ts
+++ b/src/phases/types.ts
@@ -1,5 +1,7 @@
 export interface Phase {
   title: string;
+  /** Phase topic extracted from the "Welcome to <topic>" marker — more descriptive than the FIAP default title */
+  topic: string | null;
   isActive: boolean;
   index: number;
   courseId: string;

--- a/src/subjects/index.ts
+++ b/src/subjects/index.ts
@@ -45,9 +45,9 @@ export async function getSubjectList(page: Page, activePhase: Phase): Promise<Su
         current = { title, classes: [] };
         result.push(current);
       } else if (current) {
-        // Skip activity items (assignments, quizzes)
+        // Skip activity items (assignments, quizzes) and external content placeholders
         if (item.querySelector('.t-conteudo-atividades')) continue;
-        if (!title) continue;
+        if (!title || title === 'Conteúdos externos') continue;
 
         const digitalLink = item.querySelector('.t-conteudo-digital') as HTMLAnchorElement | null;
         const pdfLink = item.querySelector('.t-conteudo-pdf') as HTMLAnchorElement | null;


### PR DESCRIPTION
## Summary

- Adds `src/notion/` module to resolve Notion collection IDs for the active phase and match scraped `ClassItem` titles to their corresponding Notion Conteúdo page IDs
- Adds `src/cli/` module with an interactive phase selector — loops until the user exits, so multiple phases can be synced in one session
- Fixes active phase detection fallback for completed courses where no CSS/ARIA active marker exists
- Extracts real phase topic from the "Welcome to <topic>" marker for better display labels
- Adds spinners and prefixed logs (`[scraper]` / `[notion]`) for clearer feedback during sync
- Adds `@notionhq/client`, `@inquirer/prompts`, and `ora` dependencies

## Notes

- Read-only from Notion — no pages are created or modified
- PDF sync is out of scope; PDFs were already manually uploaded to all Conteúdo entries
- Notion SDK v5.15.0 uses `dataSources.query` with a collection ID (not database page ID) — see `resolveDataSourceId()` in `src/notion/index.ts`

## Preview
<img width="660" height="426" alt="image" src="https://github.com/user-attachments/assets/7bdf146f-9188-4c96-a72a-4fea8a6d9983" />

Closes #4
Closes #13