### PR TITLE
feat: extract and persist HLS video URLs from class content pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ downloads
 #ai
 .claude
 .playwright-mcp
+
+# scraping output (local only, not committed)
+data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ This is a TypeScript + Puppeteer web scraper that authenticates on the FIAP cour
 4. `cli/` — Interactive prompt: user selects a phase; loops until exit
 5. `subjects/` — Scrape subjects and classes for the selected phase
 6. `notion/` — Resolve Conteúdo DB collection ID, match `ClassItem.title` → Notion page ID
-7. (Next) Extract HLS video URLs from each class's `contentUrl`, upload to Notion
+7. `content-video/` — For each unfetched class, open a new tab, navigate to `contentUrl`, scrape `pos_videos_container` inside `#iframecontent`, extract all playlist videos (title, duration, HLS URL derived from thumbnail CDN hash), write to state, close tab
 
 **Module layout**:
 - `src/auth/` — Login and course page access verification
@@ -39,14 +39,45 @@ This is a TypeScript + Puppeteer web scraper that authenticates on the FIAP cour
 - `src/subjects/` — Complex DOM evaluation to build `Subject → ClassItem[]` hierarchy
 - `src/notion/` — Resolve Notion collection IDs and match scraped classes to Conteúdo entries
 - `src/cli/` — Interactive phase selector using `@inquirer/prompts`
+- `src/content-video/` — Sequential video scraper; `getAllVideos()` opens one tab per class, closes after scraping, calls `onClassDone` callback for incremental persistence
+- `src/state/` — Read/write `output/output.json`; `upsertPhase()` merges scraped data preserving existing videos; `setPhaseVideos()` marks classes as fetched
 - `src/constants/` — FIAP URLs (single source of truth)
+- `src/utils.ts` — `assertNotBlocked(page)`: detects CloudFront WAF block pages by checking `document.title` for "error"; called after every `page.goto()`
 
 **Key types** (in each module's `types.ts`):
 - `Phase`: title, topic (from "Welcome to \<topic\>" marker), isActive, index, courseId
 - `Subject`: title, classes (ClassItem[])
 - `ClassItem`: title, contentUrl, pdfUrl, progress
+- `ContentVideo`: title, duration, hlsUrl
+- `ClassVideos`: classTitle, videos (ContentVideo[])
+- `StateClass`: extends ClassItem with notionPageId, videosFetched (bool), videos (ContentVideo[])
+- `ScraperOutput`: phases (StatePhase[]), lastUpdated (ISO timestamp)
 
 **DOM scraping pattern**: `phases/` uses `page.$$eval()` for batch extraction; `subjects/` uses a single `page.evaluate()` call running client-side JS against the full document.
+
+## State Persistence
+
+All scraping output is persisted to `output/output.json` (gitignored). This file is the single source of truth for sync and video fetch status across runs.
+
+**`videosFetched` flag**: set to `true` on a class only after `scrapeClassVideos()` completes successfully. A partial fetch (e.g. interrupted mid-run) leaves unfetched classes with `videosFetched: false`, so re-running resumes from where it stopped. Never pre-set this flag — it must only be written after confirmed completion.
+
+**Incremental writes**: `onClassDone` callback in `getAllVideos()` writes each class to disk immediately after scraping it, so a crash never loses completed work.
+
+**Resync safety**: `upsertPhase()` looks up each class by subject title + class title and preserves its `videos` and `videosFetched`. A resync only overwrites scraped metadata (contentUrl, pdfUrl, progress, notionPageId). Renamed classes are treated as new (videos reset).
+
+## CLI Status Indicators
+
+The phase selector shows `[S][V]` prefixes:
+- `S` — synced (subjects/classes scraped and matched to Notion)
+- `V` — videos: `✓` all fetched · `~` partially fetched · ` ` none fetched
+
+Action menu CTA adapts based on video status: `"Get Videos"` / `"Continue fetching videos"` / `"Re-fetch Videos"`.
+
+## CloudFront Rate Limiting
+
+FIAP video content is served via CloudFront with a WAF rule that blocks rapid parallel requests. Opening multiple tabs simultaneously (even with staggered delays) triggers 403 blocks mid-run.
+
+**Strategy**: always fetch videos sequentially, one class at a time, each in its own tab that is closed immediately after. Do not parallelize or batch class content page requests. The main page (course listing) is never navigated during video fetching — only new tabs are used.
 
 ## Environment
 
@@ -80,6 +111,48 @@ Items skipped during subject scraping (section headers, not real content):
 - `is-marcador` items starting with `"Welcome"` or `"Atividade:"`
 - Regular items titled `"Conteúdos externos"`
 
+## FIAP Class Content Page Structure
+
+Each `ClassItem.contentUrl` points to `https://on.fiap.com.br/mod/conteudoshtml/view.php?id=...`.
+The video content is inside an iframe (`#iframecontent`) which loads a separate HTML page.
+
+**Accessing the iframe**: `document.querySelector('#iframecontent').contentDocument` (same-origin, accessible directly).
+
+Inside the iframe, the `.pos_videos_container` div holds the entire video player UI:
+
+```
+.pos_videos_container
+  .pos_videos_header          ← "Vídeo X de Y" (e.g. "Vídeo 01 de 04")
+  .pos_videos_features
+    pos-highlighted-video.feature_highlighted
+      .pos_highlighted_video
+        iframe[src]           ← embed URL for the *currently selected* video only:
+                                  https://on.fiap.com.br/local/streaming/embed.php?video={videoHash}
+    pos-playlist.feature_playlist
+      .pos_playlist_container
+        .pos-playlist-items
+          .pos-playlist-item[.selected]   ← one per video; .selected = currently playing
+            .pos-playlist-image-thumbnail (img[src])  ← thumbnail URL (see HLS derivation below)
+            .pos-playlist-number-thumbnail            ← "01", "02", …
+            .pos-playlist-item-title                  ← video title
+            .pos-playlist-duration                    ← "MM:SS"
+            .pos-playlist-progress-bar                ← progress status text
+```
+
+**HLS URL derivation** (no need to navigate to embed pages):
+
+The thumbnail URL and HLS master playlist share the same CDN hash:
+- Thumbnail: `https://d1l755to62lquf.cloudfront.net/{hash}/Thumbnails/file.0000001.jpg`
+- HLS:       `https://d1l755to62lquf.cloudfront.net/{hash}/HLS/file.m3u8`
+
+Extract the hash from any playlist item's thumbnail `src` and substitute the path suffix to get the HLS URL. This works for all videos in the playlist without clicking or navigating.
+
+**Embed page** (`embed.php?video={videoHash}`): Video.js player initialized via `[data-setup]` attribute:
+```json
+{ "sources": { "type": "application/x-mpegURL", "src": "https://.../{hash}/HLS/file.m3u8" }, ... }
+```
+The embed page is only needed if the thumbnail-based derivation ever fails.
+
 ## Notion Workspace Structure
 
 ```
@@ -97,6 +170,6 @@ Inline databases (Disciplinas, Conteúdo) have unique IDs per Fase page and are 
 ## Code Conventions
 
 - Strict TypeScript (`tsconfig.json` has `strict: true`)
-- Imports resolve from `src/` as base URL (e.g., `import { FIAP_URLS } from 'constants'`)
+- Imports use relative paths (e.g., `import { FIAP_URLS } from '../constants'`) — bare imports like `'constants'` collide with `@types/node` built-ins
 - Prettier enforced: single quotes, semicolons, trailing commas, 100-char print width
 - `ora` is pinned to **v5** — v6+ dropped CommonJS support and will break this project (`"module": "commonjs"` in `tsconfig.json`)

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ A work in progress... :hourglass_flowing_sand:
 
 ## Description
 
-This project automates syncing study materials from my FIAP course into my personal Notion workspace. It scrapes the course platform and uploads video content to the corresponding Notion pages, keeping course content organized without manual effort.
+This project automates syncing study materials from my FIAP course into my personal Notion workspace. It scrapes the course platform, extracts course structure and HLS video URLs, and persists everything locally — ready for upload to Notion.
 
 The scraper will:
 
 1. Authenticate on the FIAP course page.
-2. Detect the active phase and extract its subjects and classes.
-3. Match each class to its corresponding page in the Notion Conteúdo database.
-4. Extract HLS video URLs for each class.
-5. Upload the videos to Notion.
+2. Present an interactive phase selector with sync and video status indicators.
+3. Scrape subjects and classes for the selected phase, matching each to its Notion page.
+4. Extract HLS video URLs for each class, persisting progress to `output/output.json` after every class so runs are resumable on crash or CloudFront block.
+5. _(Upcoming)_ Upload videos to Notion.
 
 ## How It Works
 
@@ -20,25 +20,38 @@ The scraper will:
 sequenceDiagram
     actor user as User
     participant scraper as Scraper
+    participant state as output.json
     participant fiap as FIAP Platform
     participant notion as Notion
 
     user->>scraper: npm run dev
     scraper->>fiap: Login + fetch phases
     fiap-->>scraper: Phase list
-    scraper->>user: Select a phase
-    user-->>scraper: Fase N
+    scraper->>state: Load local data (last sync timestamp)
+    state-->>scraper: Synced phases + video status
 
-    scraper->>fiap: Scrape subjects + classes
-    fiap-->>scraper: ClassItem[]
+    loop Until exit
+        scraper->>user: Select phase [S][V] status indicators
+        user-->>scraper: Fase N + action
 
-    scraper->>notion: Query Conteúdo DB
-    notion-->>scraper: Existing entries
-    scraper->>scraper: Match titles → page IDs
+        opt Sync (first run only)
+            scraper->>fiap: Scrape subjects + classes
+            fiap-->>scraper: ClassItem[]
+            scraper->>notion: Query Conteúdo DB
+            notion-->>scraper: Existing entries
+            scraper->>scraper: Match titles → page IDs
+            scraper->>state: Upsert phase (preserve existing videos)
+        end
 
-    scraper->>fiap: Extract HLS video URLs
-    fiap-->>scraper: Video URLs
-    scraper->>notion: Upload videos
+        opt Get Videos
+            loop Each unfetched class (sequential)
+                scraper->>fiap: Navigate to class content page (new tab)
+                fiap-->>scraper: Playlist items + thumbnail URLs
+                scraper->>scraper: Derive HLS URLs from CDN hash
+                scraper->>state: Write class videos immediately
+            end
+        end
+    end
 ```
 
 ## Notion Workspace Structure

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,5 +1,6 @@
 import { Page } from 'puppeteer';
 import { FIAP_URLS } from '../constants';
+import { assertNotBlocked } from '../utils';
 import { LoginCredentials } from './types';
 
 export async function loginToFIAP(page: Page, { username, password }: LoginCredentials) {
@@ -14,10 +15,12 @@ export async function loginToFIAP(page: Page, { username, password }: LoginCrede
     page.click('#loginbtn-plataforma'),
     page.waitForNavigation({ waitUntil: 'networkidle0' }),
   ]);
+  await assertNotBlocked(page);
 }
 
 export async function ensureAccessToCoursePage(page: Page) {
   await page.goto(FIAP_URLS.COURSE, { waitUntil: 'networkidle0' });
+  await assertNotBlocked(page);
 
   const courseTitleSelector = '.conteudo-digital-disciplina-unidade';
   const courseTitle = await page.$(courseTitleSelector);
@@ -25,5 +28,4 @@ export async function ensureAccessToCoursePage(page: Page) {
   if (!courseTitle) {
     throw new Error('Failed to access course page');
   }
-
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,23 +2,69 @@ import { select, Separator } from '@inquirer/prompts';
 import { Phase } from '../phases/types';
 import { getPhaseDisplayTitle } from '../phases';
 
-/** Returns the selected Phase, or null if the user chose to exit. */
-export async function selectPhase(phases: Phase[]): Promise<Phase | null> {
+export type PhaseAction = 'sync' | 'get-videos' | 'go-back' | 'exit';
+
+export type PhaseSelectionResult =
+  | { type: 'phase'; phase: Phase }
+  | { type: 'exit' };
+
+/**
+ * Prompts the user to choose an action after a phase is selected.
+ * Labels adapt based on whether the phase is synced and whether it has videos.
+ */
+const VIDEO_ACTION_LABEL: Record<'~' | ' ', string> = {
+  '~': 'Continue fetching videos',
+  ' ': 'Get Videos',
+};
+
+export async function selectPhaseAction(isSynced: boolean, videoStatus: '~' | ' '): Promise<PhaseAction> {
+  return select<PhaseAction>({
+    message: 'What would you like to do?',
+    choices: [
+      ...(!isSynced ? [{ name: 'Sync', value: 'sync' as PhaseAction }] : []),
+      ...(isSynced ? [{ name: VIDEO_ACTION_LABEL[videoStatus], value: 'get-videos' as PhaseAction }] : []),
+      { name: 'Go back', value: 'go-back' },
+      new Separator(),
+      { name: 'Exit', value: 'exit' },
+    ],
+  });
+}
+
+/**
+ * Prompts the user to select a phase.
+ * [✓][ ] = synced but no videos, [✓][✓] = done (disabled), [ ][ ] = not synced.
+ */
+export async function selectPhase(
+  phases: Phase[],
+  syncedPhaseTitles: Set<string>,
+  phaseVideoStatus: Map<string, '✓' | '~' | ' '>,
+): Promise<PhaseSelectionResult> {
   const defaultPhase = phases.find((p) => p.isActive) ?? phases[0];
 
-  return select<Phase | null>({
-    message: 'Select a phase to sync:',
+  type Choice = Phase | 'exit';
+
+  console.log('  [S][V]  S = Synced · V = Videos (✓ all · ~ partial)');
+  const result = await select<Choice>({
+    message: 'Select a phase:',
     choices: [
       ...phases.map((phase) => {
+        const synced = syncedPhaseTitles.has(phase.title);
+        const videoMark = phaseVideoStatus.get(phase.title) ?? ' ';
         const label = getPhaseDisplayTitle(phase);
+        const suffix = phase.isActive ? ' (active)' : '';
+        const done = synced && videoMark === '✓';
         return {
-          name: phase.isActive ? `${label} (active)` : label,
-          value: phase as Phase | null,
+          name: `[${synced ? '✓' : ' '}][${videoMark}] ${label}${suffix}`,
+          value: phase as Choice,
+          disabled: done,
         };
       }),
       new Separator(),
-      { name: 'Exit', value: null },
+      { name: 'Exit', value: 'exit' as Choice },
     ],
     default: defaultPhase,
   });
+
+  if (result === 'exit') return { type: 'exit' };
+  return { type: 'phase', phase: result };
 }

--- a/src/content-video/index.ts
+++ b/src/content-video/index.ts
@@ -1,0 +1,90 @@
+import { Page } from 'puppeteer';
+import { Subject } from '../subjects/types';
+import { assertNotBlocked } from '../utils';
+import { ContentVideo } from './types';
+
+/**
+ * Derives the HLS master playlist URL from a playlist item's thumbnail URL.
+ * Both share the same CDN hash: .cloudfront.net/{hash}/Thumbnails/... → .cloudfront.net/{hash}/HLS/file.m3u8
+ */
+function hlsUrlFromThumbnail(thumbnailUrl: string): string {
+  return thumbnailUrl.replace(/\/Thumbnails\/.*$/, '/HLS/file.m3u8');
+}
+
+/**
+ * Scrapes all playlist videos from a class content page.
+ * Does not navigate away after — caller is responsible for page state.
+ */
+async function scrapeClassVideos(page: Page, contentUrl: string): Promise<ContentVideo[]> {
+  const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — generous for slow CDN, but catches crashed/hung pages
+
+  await page.goto(contentUrl, { waitUntil: 'networkidle0', timeout: TIMEOUT_MS });
+
+  await assertNotBlocked(page);
+
+  // The iframe loads asynchronously — wait until .pos_videos_container is present inside it
+  await page.waitForFunction(() => {
+    const iframe = document.querySelector('#iframecontent') as HTMLIFrameElement | null;
+    return !!iframe?.contentDocument?.querySelector('.pos_videos_container');
+  }, { timeout: TIMEOUT_MS });
+
+  const rawVideos = await page.evaluate(() => {
+    const iframe = document.querySelector('#iframecontent') as HTMLIFrameElement | null;
+    const doc = iframe?.contentDocument;
+    if (!doc) return [];
+
+    return Array.from(doc.querySelectorAll('.pos-playlist-item')).map((item) => ({
+      title: item.querySelector('.pos-playlist-item-title')?.textContent?.trim() ?? '',
+      duration: item.querySelector('.pos-playlist-duration')?.textContent?.trim() ?? '',
+      // .src gives the absolute URL; used to derive the HLS URL via the shared CDN hash
+      thumbnailUrl: (item.querySelector('.pos-playlist-image-thumbnail') as HTMLImageElement | null)?.src ?? '',
+    }));
+  });
+
+  return rawVideos
+    .filter((v) => v.thumbnailUrl)
+    .map((v) => ({
+      title: v.title,
+      duration: v.duration,
+      hlsUrl: hlsUrlFromThumbnail(v.thumbnailUrl),
+    }));
+}
+
+export interface ClassVideos {
+  classTitle: string;
+  videos: ContentVideo[];
+}
+
+/**
+ * Sequentially scrapes videos for every class in the given subjects.
+ * Each class is opened in a new tab and closed when done, keeping the
+ * original page (course listing) intact throughout.
+ * Classes without a contentUrl are skipped.
+ * Calls onClassDone after each class completes so the caller can persist progress immediately.
+ */
+export async function getAllVideos(
+  page: Page,
+  subjects: Subject[],
+  options?: { onClassDone?: (result: ClassVideos) => void },
+): Promise<ClassVideos[]> {
+  const onClassDone = options?.onClassDone;
+  const results: ClassVideos[] = [];
+  const browser = page.browser();
+
+  for (const subject of subjects) {
+    for (const classItem of subject.classes) {
+      if (!classItem.contentUrl) continue;
+      const tab = await browser.newPage();
+      try {
+        const videos = await scrapeClassVideos(tab, classItem.contentUrl);
+        const result: ClassVideos = { classTitle: classItem.title, videos };
+        results.push(result);
+        onClassDone?.(result);
+      } finally {
+        await tab.close();
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/content-video/types.ts
+++ b/src/content-video/types.ts
@@ -1,0 +1,5 @@
+export interface ContentVideo {
+  title: string;
+  duration: string;
+  hlsUrl: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ import { loginToFIAP, ensureAccessToCoursePage } from './auth';
 import { getPhaseList, getPhaseDisplayTitle } from './phases';
 import { getSubjectList } from './subjects';
 import { getPhaseCollections, matchClassesToNotion } from './notion';
-import { selectPhase } from './cli';
+import { selectPhase, selectPhaseAction } from './cli';
+import { getAllVideos } from './content-video';
+import { hasLocalData, readOutput, writeOutput, upsertPhase, setPhaseVideos } from './state';
 
 async function main() {
   if (!process.env.FIAP_USERNAME || !process.env.FIAP_PASSWORD) {
@@ -16,7 +18,7 @@ async function main() {
     throw new Error('Please provide NOTION_TOKEN and NOTION_PHASES_DB_ID in .env file');
   }
 
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({ headless: false });
 
   try {
     let spinner = ora('[scraper] Logging in to FIAP...').start();
@@ -35,27 +37,100 @@ async function main() {
     const phases = await getPhaseList(page);
     spinner.succeed(`[scraper] Found ${phases.length} phases`);
 
+    if (hasLocalData()) {
+      const { lastUpdated } = readOutput();
+      console.log(`\nℹ️  Local scraping data found (last synced: ${new Date(lastUpdated).toLocaleString()})`);
+    }
+
     const notion = new Client({ auth: process.env.NOTION_TOKEN });
 
     while (true) {
       console.log();
-      const selectedPhase = await selectPhase(phases);
-      if (!selectedPhase) break;
+      const output = readOutput();
+      const syncedPhaseTitles = new Set(output.phases.map((p) => p.title));
+      const phaseVideoStatus = new Map(
+        output.phases.map((p) => {
+          const allClasses = p.subjects.flatMap((s) => s.classes).filter((c) => c.contentUrl);
+          const fetchedCount = allClasses.filter((c) => c.videosFetched).length;
+          const mark = fetchedCount === 0 ? ' ' : fetchedCount === allClasses.length ? '✓' : '~';
+          return [p.title, mark as '✓' | '~' | ' '];
+        }),
+      );
+      const selection = await selectPhase(phases, syncedPhaseTitles, phaseVideoStatus);
 
+      if (selection.type === 'exit') break;
+
+      const { phase: selectedPhase } = selection;
       const displayTitle = getPhaseDisplayTitle(selectedPhase);
+      const isSynced = syncedPhaseTitles.has(selectedPhase.title);
+      // '✓' phases are disabled in the selector so only '~' or ' ' reach here
+      const videoStatus = (phaseVideoStatus.get(selectedPhase.title) ?? ' ') as '~' | ' ';
 
-      spinner = ora(`[scraper] Scraping subjects for ${displayTitle}...`).start();
-      const subjects = await getSubjectList(page, selectedPhase);
-      const classCount = subjects.reduce((sum, s) => sum + s.classes.length, 0);
-      spinner.succeed(`[scraper] Found ${subjects.length} subjects, ${classCount} classes`);
+      let action = await selectPhaseAction(isSynced, videoStatus);
+      if (action === 'go-back') continue;
+      if (action === 'exit') break;
 
-      spinner = ora('[notion] Matching classes...').start();
-      const collections = await getPhaseCollections(notion, selectedPhase);
-      const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects);
-      spinner.succeed(`[notion] Matched ${classMap.size}/${classCount} classes`);
+      console.log();
 
-      if (unmatched.length) {
-        console.warn(`⚠️  [notion] Unmatched (${unmatched.length}):`, unmatched);
+      if (action === 'sync') {
+        spinner = ora(`[scraper] Scraping subjects for ${displayTitle}...`).start();
+        const subjects = await getSubjectList(page, selectedPhase);
+        const classCount = subjects.reduce((sum, s) => sum + s.classes.length, 0);
+        spinner.succeed(`[scraper] Found ${subjects.length} subjects, ${classCount} classes`);
+
+        spinner = ora('[notion] Matching classes...').start();
+        const collections = await getPhaseCollections(notion, selectedPhase);
+        const { classMap, unmatched } = await matchClassesToNotion(notion, collections, subjects);
+        spinner.succeed(`[notion] Matched ${classMap.size}/${classCount} classes`);
+
+        if (unmatched.length) {
+          console.warn(`⚠️  [notion] Unmatched (${unmatched.length}):`, unmatched);
+        }
+
+        writeOutput(upsertPhase(readOutput(), selectedPhase, subjects, classMap));
+        spinner.succeed(`[scraper] Saved phase data to output/output.json`);
+      }
+
+      if (action === 'get-videos') {
+        // Re-read from output, skipping classes already fully fetched
+        const phaseData = readOutput().phases.find((p) => p.title === selectedPhase.title)!;
+        const subjects = phaseData.subjects.map((s) => ({
+          title: s.title,
+          classes: s.classes
+            .filter((c) => !c.videosFetched)
+            .map((c) => ({
+              title: c.title,
+              contentUrl: c.contentUrl,
+              pdfUrl: c.pdfUrl,
+              progress: c.progress,
+            })),
+        }));
+
+        const classesWithUrlCount = subjects
+          .flatMap((s) => s.classes)
+          .filter((c) => c.contentUrl !== null).length;
+        let fetchedCount = 0;
+        spinner = ora(`[scraper] Fetching videos... (0/${classesWithUrlCount} classes)`).start();
+        let classVideos;
+        try {
+          classVideos = await getAllVideos(page, subjects, {
+            onClassDone: ({ classTitle, videos }) => {
+              spinner.text = `[scraper] Fetching videos... (${++fetchedCount}/${classesWithUrlCount} classes)`;
+              // Write incrementally after each class so progress is never lost
+              writeOutput(setPhaseVideos(readOutput(), selectedPhase.title, [{ classTitle, videos }]));
+            },
+          });
+        } catch (err) {
+          spinner.fail(`[scraper] Fetching videos interrupted (${fetchedCount}/${classesWithUrlCount} classes)`);
+          throw err;
+        }
+
+        const totalVideos = classVideos.reduce((sum, c) => sum + c.videos.length, 0);
+        if (totalVideos === 0) {
+          spinner.warn('\n⚠️  [scraper] No videos found');
+        } else {
+          spinner.succeed(`[scraper] Found ${totalVideos} videos across ${classVideos.length} classes, saved to output/output.json`);
+        }
       }
     }
   } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,14 +110,17 @@ async function main() {
           .flatMap((s) => s.classes)
           .filter((c) => c.contentUrl !== null).length;
         let fetchedCount = 0;
+        // Read once upfront; onClassDone updates this local copy and writes it,
+        // avoiding redundant disk reads on every class completion
+        let currentOutput = readOutput();
         spinner = ora(`[scraper] Fetching videos... (0/${classesWithUrlCount} classes)`).start();
         let classVideos;
         try {
           classVideos = await getAllVideos(page, subjects, {
             onClassDone: ({ classTitle, videos }) => {
               spinner.text = `[scraper] Fetching videos... (${++fetchedCount}/${classesWithUrlCount} classes)`;
-              // Write incrementally after each class so progress is never lost
-              writeOutput(setPhaseVideos(readOutput(), selectedPhase.title, [{ classTitle, videos }]));
+              currentOutput = setPhaseVideos(currentOutput, selectedPhase.title, [{ classTitle, videos }]);
+              writeOutput(currentOutput);
             },
           });
         } catch (err) {

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import path from 'path';
+import { Phase } from '../phases/types';
+import { Subject } from '../subjects/types';
+import { ClassNotionMap } from '../notion/types';
+import { ContentVideo } from '../content-video/types';
+import { ScraperOutput, StatePhase } from './types';
+
+const OUTPUT_DIR = path.join(process.cwd(), 'data');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'output.json');
+
+const EMPTY_OUTPUT: ScraperOutput = { phases: [], lastUpdated: '' };
+
+export function hasLocalData(): boolean {
+  return fs.existsSync(OUTPUT_FILE);
+}
+
+export function readOutput(): ScraperOutput {
+  if (!hasLocalData()) return { ...EMPTY_OUTPUT };
+  return JSON.parse(fs.readFileSync(OUTPUT_FILE, 'utf-8')) as ScraperOutput;
+}
+
+export function writeOutput(output: ScraperOutput): void {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify({ ...output, lastUpdated: new Date().toISOString() }, null, 2));
+}
+
+export function clearOutput(): void {
+  if (fs.existsSync(OUTPUT_FILE)) fs.unlinkSync(OUTPUT_FILE);
+}
+
+/**
+ * Merges a freshly scraped phase (subjects + classes + Notion IDs) into the
+ * output, preserving any existing videos already saved for each class.
+ */
+export function upsertPhase(
+  output: ScraperOutput,
+  phase: Phase,
+  subjects: Subject[],
+  classMap: ClassNotionMap,
+): ScraperOutput {
+  const existingPhase = output.phases.find((p) => p.title === phase.title);
+
+  const updatedPhase: StatePhase = {
+    title: phase.title,
+    subjects: subjects.map((subject) => ({
+      title: subject.title,
+      classes: subject.classes.map((classItem) => {
+        // Preserve existing videos if this class was already scraped
+        const existingClass = existingPhase?.subjects
+          .find((s) => s.title === subject.title)
+          ?.classes.find((c) => c.title === classItem.title);
+
+        return {
+          title: classItem.title,
+          contentUrl: classItem.contentUrl,
+          pdfUrl: classItem.pdfUrl,
+          progress: classItem.progress,
+          notionPageId: classMap.get(classItem.title) ?? null,
+          videosFetched: existingClass?.videosFetched ?? false,
+          videos: existingClass?.videos ?? [],
+        };
+      }),
+    })),
+  };
+
+  const phases = existingPhase
+    ? output.phases.map((p) => (p.title === phase.title ? updatedPhase : p))
+    : [...output.phases, updatedPhase];
+
+  return { ...output, phases };
+}
+
+/**
+ * Writes the fetched videos into their corresponding classes for a given phase.
+ */
+export function setPhaseVideos(
+  output: ScraperOutput,
+  phaseTitle: string,
+  classVideos: { classTitle: string; videos: ContentVideo[] }[],
+): ScraperOutput {
+  const videosByClass = new Map(classVideos.map(({ classTitle, videos }) => [classTitle, videos]));
+
+  return {
+    ...output,
+    phases: output.phases.map((phase) => {
+      if (phase.title !== phaseTitle) return phase;
+      return {
+        ...phase,
+        subjects: phase.subjects.map((subject) => ({
+          ...subject,
+          classes: subject.classes.map((cls) => {
+            const videos = videosByClass.get(cls.title);
+            return videos !== undefined
+              ? { ...cls, videos, videosFetched: true }
+              : cls;
+          }),
+        })),
+      };
+    }),
+  };
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,26 @@
+import { ContentVideo } from '../content-video/types';
+
+export interface StateClass {
+  title: string;
+  contentUrl: string | null;
+  pdfUrl: string | null;
+  progress: number | null;
+  notionPageId: string | null;
+  videosFetched: boolean;
+  videos: ContentVideo[];
+}
+
+export interface StateSubject {
+  title: string;
+  classes: StateClass[];
+}
+
+export interface StatePhase {
+  title: string;
+  subjects: StateSubject[];
+}
+
+export interface ScraperOutput {
+  phases: StatePhase[];
+  lastUpdated: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,15 @@
+import { Page } from 'puppeteer';
+
+/**
+ * Throws if the current page is a CloudFront block page.
+ * CloudFront serves blocks as rendered HTML with "error" in the title,
+ * so we check content rather than HTTP status which may not propagate reliably.
+ */
+export async function assertNotBlocked(page: Page): Promise<void> {
+  const isBlocked = await page.evaluate(() => document.title.toLowerCase().includes('error'));
+  if (isBlocked) {
+    throw new Error(
+      `CloudFront blocked the request for ${page.url()} — stop and retry later.`,
+    );
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,10 @@ import { Page } from 'puppeteer';
  * so we check content rather than HTTP status which may not propagate reliably.
  */
 export async function assertNotBlocked(page: Page): Promise<void> {
-  const isBlocked = await page.evaluate(() => document.title.toLowerCase().includes('error'));
+  // CloudFront WAF block pages always contain this specific string in the body
+  const isBlocked = await page.evaluate(() =>
+    document.body?.textContent?.includes('The request could not be satisfied'),
+  );
   if (isBlocked) {
     throw new Error(
       `CloudFront blocked the request for ${page.url()} — stop and retry later.`,


### PR DESCRIPTION
## Summary

- Implements sequential HLS video URL extraction from FIAP class content pages
- Persists all scraping output to `output/output.json` with incremental writes per class, so crashes and CloudFront blocks never lose completed work
- Adds `[S][V]` phase status indicators to the CLI; fully-done phases (`[✓][✓]`) are disabled — no re-entry once complete
- `assertNotBlocked()` utility detects CloudFront WAF block pages after every navigation

## How it works

1. User selects an unsynced phase → **Sync** scrapes subjects/classes and matches to Notion
2. User selects **Get Videos** → scraper opens one new tab per class, extracts playlist items, derives HLS URLs from thumbnail CDN hashes, writes to `output.json`, closes tab
3. Phase is marked `[✓][✓]` and disabled in the selector

## Key decisions

- **Sequential fetching** (one tab at a time) to avoid triggering CloudFront WAF, which blocks parallel requests mid-run
- **`videosFetched` flag** set only on successful completion — partial fetches resume correctly on next run
- **5-minute timeout** on page navigation and iframe wait to catch crashed/hung pages without hanging forever

Closes #8