### PR TITLE
feat: download and convert HLS videos to MP4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ FIAP_PASSWORD=your_password
 
 NOTION_TOKEN=your_notion_token
 NOTION_PHASES_DB_ID=your_notion_phases_db_id
+
+# Optional — limit parallel ffmpeg processes in Video Converter (default: unlimited)
+# FFMPEG_CONCURRENCY=5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,66 +22,93 @@ No test runner is configured yet. Node.js >= 24.x and npm >= 11.x required.
 
 ## Architecture
 
-This is a TypeScript + Puppeteer web scraper that authenticates on the FIAP course platform, extracts course structure, matches classes to Notion, and (next) uploads HLS videos.
+This is a TypeScript CLI tool for the FIAP course platform. It has two modes: a **Scraper** (Puppeteer) that authenticates, extracts course structure, matches classes to Notion, and scrapes HLS video URLs; and a **Video Converter** (ffmpeg) that downloads those HLS streams and remuxes them to MP4.
 
-**Execution flow** (`src/index.ts`):
-1. Launch Puppeteer browser
-2. `auth/` — Log in with credentials from `.env`, navigate to course page
-3. `phases/` — Scrape all available phases
-4. `cli/` — Interactive prompt: user selects a phase; loops until exit
-5. `subjects/` — Scrape subjects and classes for the selected phase
-6. `notion/` — Resolve Conteúdo DB collection ID, match `ClassItem.title` → Notion page ID
-7. `content-video/` — For each unfetched class, open a new tab, navigate to `contentUrl`, scrape `pos_videos_container` inside `#iframecontent`, extract all playlist videos (title, duration, HLS URL derived from thumbnail CDN hash), write to state, close tab
+**Top-level flow** (`src/index.ts`):
+
+1. `selectMode()` — user picks Scraper, Video Converter, or Exit. Converter is disabled when no scraped data exists.
+2. **Scraper** (`runScraper()`): validates env vars → launches Puppeteer → auth → phase list → `while(true)` loop (select phase → sync or get-videos)
+3. **Converter** (`runConverter()`): validates ffmpeg on PATH → reads `data/output.json` → `while(true)` loop (select phase → convert videos). Fully offline — no browser, no Notion.
 
 **Module layout**:
+
 - `src/auth/` — Login and course page access verification
 - `src/phases/` — Scrape phase list; `getPhaseDisplayTitle()` builds the human-readable label from `Phase.topic`
 - `src/subjects/` — Complex DOM evaluation to build `Subject → ClassItem[]` hierarchy
 - `src/notion/` — Resolve Notion collection IDs and match scraped classes to Conteúdo entries
-- `src/cli/` — Interactive phase selector using `@inquirer/prompts`
-- `src/content-video/` — Sequential video scraper; `getAllVideos()` opens one tab per class, closes after scraping, calls `onClassDone` callback for incremental persistence
-- `src/state/` — Read/write `output/output.json`; `upsertPhase()` merges scraped data preserving existing videos; `setPhaseVideos()` marks classes as fetched
+- `src/cli/` — Top-level mode selector, scraper phase/action selectors, converter phase/action selectors; all using `@inquirer/prompts`
+- `src/content-video/` — Sequential video URL scraper; `getAllVideos()` opens one tab per class, closes after scraping, calls `onClassDone` callback for incremental persistence
+- `src/download/` — Video converter; `convertPhaseVideos()` downloads all unconverted videos in parallel via ffmpeg (`-c copy` remux to MP4), calls `onVideoDone`/`onProgress` callbacks
+- `src/state/` — Read/write `data/output.json`; `upsertPhase()` merges scraped data preserving existing videos and conversion status; `setPhaseVideos()` marks classes as fetched; `setVideoConverted()` marks individual videos as converted
 - `src/constants/` — FIAP URLs (single source of truth)
 - `src/utils.ts` — `assertNotBlocked(page)`: detects CloudFront WAF block pages by checking `document.title` for "error"; called after every `page.goto()`
 
 **Key types** (in each module's `types.ts`):
+
 - `Phase`: title, topic (from "Welcome to \<topic\>" marker), isActive, index, courseId
 - `Subject`: title, classes (ClassItem[])
 - `ClassItem`: title, contentUrl, pdfUrl, progress
-- `ContentVideo`: title, duration, hlsUrl
+- `ContentVideo`: title, duration, hlsUrl, converted (bool)
 - `ClassVideos`: classTitle, videos (ContentVideo[])
 - `StateClass`: extends ClassItem with notionPageId, videosFetched (bool), videos (ContentVideo[])
+- `StatePhase`: title (display title from `getPhaseDisplayTitle()`), subjects (StateSubject[])
 - `ScraperOutput`: phases (StatePhase[]), lastUpdated (ISO timestamp)
 
 **DOM scraping pattern**: `phases/` uses `page.$$eval()` for batch extraction; `subjects/` uses a single `page.evaluate()` call running client-side JS against the full document.
 
 ## State Persistence
 
-All scraping output is persisted to `output/output.json` (gitignored). This file is the single source of truth for sync and video fetch status across runs.
+All scraping output is persisted to `data/output.json` (gitignored via `data/`). This file is the single source of truth for sync, video fetch, and conversion status across runs.
+
+**`StatePhase.title`**: stores the display title from `getPhaseDisplayTitle()` (e.g. "Fase 1 - Desenvolvimento avançado"), not the raw FIAP DOM title. All lookups in state — `upsertPhase`, `setPhaseVideos`, `setVideoConverted` — match by this display title.
 
 **`videosFetched` flag**: set to `true` on a class only after `scrapeClassVideos()` completes successfully. A partial fetch (e.g. interrupted mid-run) leaves unfetched classes with `videosFetched: false`, so re-running resumes from where it stopped. Never pre-set this flag — it must only be written after confirmed completion.
 
-**Incremental writes**: `onClassDone` callback in `getAllVideos()` writes each class to disk immediately after scraping it, so a crash never loses completed work.
+**`converted` flag**: set to `true` on each `ContentVideo` after successful ffmpeg conversion. Same resume pattern — unconverted videos are retried on next run. Written per-video via `setVideoConverted()`.
+
+**Incremental writes**: both scraper (`onClassDone`) and converter (`onVideoDone`) write to disk immediately after each unit completes, so a crash never loses completed work.
 
 **Resync safety**: `upsertPhase()` looks up each class by subject title + class title and preserves its `videos` and `videosFetched`. A resync only overwrites scraped metadata (contentUrl, pdfUrl, progress, notionPageId). Renamed classes are treated as new (videos reset).
 
-## CLI Status Indicators
+## Video Conversion
 
-The phase selector shows `[S][V]` prefixes:
+Converted videos are stored at `data/videos/<phase>/<subject>/<class>/<video>.mp4` (gitignored). Titles are sanitized for filesystem safety (unsafe chars replaced with `_`).
+
+**ffmpeg**: requires system ffmpeg on PATH. Static npm binaries (`ffmpeg-static`, `@ffmpeg-installer/ffmpeg`) crash on TLS when fetching HLS from CloudFront — do not use them. Validated at converter startup via `assertFfmpegAvailable()`.
+
+**Download strategy**: all unconverted videos in a phase download in parallel via `Promise.all`, each spawning its own ffmpeg process. Uses `-c copy` (remux, no re-encoding) and `-movflags +faststart`. Parallelism is safe here — ffmpeg fetches `.ts` segments directly from the CDN, not through the WAF-protected course pages.
+
+**Progress display**: single ora spinner shows overall count and current video progress (`time=HH:MM:SS`). Completed videos log a `✓` line above the spinner.
+
+## CLI Structure
+
+**Top-level**: `selectMode()` — Scraper / Video Converter (disabled if no `data/output.json`) / Exit.
+
+**Scraper phase selector** shows `[S][V]` prefixes:
+
 - `S` — synced (subjects/classes scraped and matched to Notion)
 - `V` — videos: `✓` all fetched · `~` partially fetched · ` ` none fetched
 
-Action menu CTA adapts based on video status: `"Get Videos"` / `"Continue fetching videos"` / `"Re-fetch Videos"`.
+Action menu CTA adapts based on video status: `"Get Videos"` / `"Continue fetching videos"`.
+
+**Converter phase selector** shows `[C]` prefix:
+
+- `C` — converted: `✓` all · `~` partial · ` ` none
+
+Only phases with fetched videos appear. Fully converted phases are disabled.
 
 ## CloudFront Rate Limiting
 
-FIAP video content is served via CloudFront with a WAF rule that blocks rapid parallel requests. Opening multiple tabs simultaneously (even with staggered delays) triggers 403 blocks mid-run.
+FIAP video content pages are served via CloudFront with a WAF rule that blocks rapid parallel requests. Opening multiple browser tabs simultaneously (even with staggered delays) triggers 403 blocks mid-run.
 
-**Strategy**: always fetch videos sequentially, one class at a time, each in its own tab that is closed immediately after. Do not parallelize or batch class content page requests. The main page (course listing) is never navigated during video fetching — only new tabs are used.
+**Scraper strategy**: always fetch video URLs sequentially, one class at a time, each in its own tab that is closed immediately after. Do not parallelize or batch class content page requests. The main page (course listing) is never navigated during video fetching — only new tabs are used.
+
+**Converter strategy**: video downloads (ffmpeg fetching HLS segments from CDN) are NOT subject to the WAF and run in parallel safely.
 
 ## Environment
 
 Copy `.env.example` to `.env`:
+
 ```
 FIAP_USERNAME=...
 FIAP_PASSWORD=...
@@ -89,11 +116,12 @@ NOTION_TOKEN=...           # Notion integration token
 NOTION_PHASES_DB_ID=...    # Page ID of the top-level Fases database (not the collection ID — resolved internally)
 ```
 
-All four vars are validated at startup — the scraper will fail fast if any are missing.
+Env vars are validated when entering **Scraper mode** only — not at global startup. The Video Converter mode is fully offline and only needs `data/output.json` + system ffmpeg.
 
 ## FIAP Course Page Structure
 
 The course page DOM hierarchy relevant to scraping:
+
 - `.conteudo-digital-disciplina-content` — one per phase
   - `.conteudo-digital-disciplina-fase[data-fase="<courseId>"]` — phase header; holds title and ID
 - `.conteudo-digital-list` — sibling of the above; contains all subjects and classes for that phase
@@ -108,6 +136,7 @@ The course page DOM hierarchy relevant to scraping:
 Phase active detection: completed courses have no reliable CSS/ARIA active marker — `isActive` is best-effort and only used to pre-select the default in the CLI prompt. Phase selection is always user-driven.
 
 Items skipped during subject scraping (section headers, not real content):
+
 - `is-marcador` items starting with `"Welcome"` or `"Atividade:"`
 - Regular items titled `"Conteúdos externos"`
 
@@ -142,15 +171,18 @@ Inside the iframe, the `.pos_videos_container` div holds the entire video player
 **HLS URL derivation** (no need to navigate to embed pages):
 
 The thumbnail URL and HLS master playlist share the same CDN hash:
+
 - Thumbnail: `https://d1l755to62lquf.cloudfront.net/{hash}/Thumbnails/file.0000001.jpg`
-- HLS:       `https://d1l755to62lquf.cloudfront.net/{hash}/HLS/file.m3u8`
+- HLS: `https://d1l755to62lquf.cloudfront.net/{hash}/HLS/file.m3u8`
 
 Extract the hash from any playlist item's thumbnail `src` and substitute the path suffix to get the HLS URL. This works for all videos in the playlist without clicking or navigating.
 
 **Embed page** (`embed.php?video={videoHash}`): Video.js player initialized via `[data-setup]` attribute:
+
 ```json
 { "sources": { "type": "application/x-mpegURL", "src": "https://.../{hash}/HLS/file.m3u8" }, ... }
 ```
+
 The embed page is only needed if the thumbnail-based derivation ever fails.
 
 ## Notion Workspace Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Converted videos are stored at `data/videos/<phase>/<subject>/<class>/<video>.mp
 
 **ffmpeg**: requires system ffmpeg on PATH. Static npm binaries (`ffmpeg-static`, `@ffmpeg-installer/ffmpeg`) crash on TLS when fetching HLS from CloudFront — do not use them. Validated at converter startup via `assertFfmpegAvailable()`.
 
-**Download strategy**: all unconverted videos in a phase download in parallel via `Promise.all`, each spawning its own ffmpeg process. Uses `-c copy` (remux, no re-encoding) and `-movflags +faststart`. Parallelism is safe here — ffmpeg fetches `.ts` segments directly from the CDN, not through the WAF-protected course pages.
+**Download strategy**: all unconverted videos in a phase download in parallel via `Promise.all`, each spawning its own ffmpeg process. Uses `-c copy` (remux, no re-encoding) and `-movflags +faststart`. Parallelism is safe here — ffmpeg fetches `.ts` segments directly from the CDN, not through the WAF-protected course pages. Concurrency can be limited via the `FFMPEG_CONCURRENCY` env var (e.g. `FFMPEG_CONCURRENCY=5`); when unset, all videos download at once.
 
 **Progress display**: single ora spinner shows overall count and current video progress (`time=HH:MM:SS`). Completed videos log a `✓` line above the spinner.
 
@@ -114,9 +114,10 @@ FIAP_USERNAME=...
 FIAP_PASSWORD=...
 NOTION_TOKEN=...           # Notion integration token
 NOTION_PHASES_DB_ID=...    # Page ID of the top-level Fases database (not the collection ID — resolved internally)
+FFMPEG_CONCURRENCY=...     # Optional — max parallel ffmpeg processes (default: unlimited)
 ```
 
-Env vars are validated when entering **Scraper mode** only — not at global startup. The Video Converter mode is fully offline and only needs `data/output.json` + system ffmpeg.
+Scraper vars are validated when entering **Scraper mode** only — not at global startup. The Video Converter mode is fully offline and only needs `data/output.json` + system ffmpeg.
 
 ## FIAP Course Page Structure
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ npm install
 cp .env.example .env
 ```
 
+### Environment variables
+
+| Variable              | Required | Description                                        |
+| --------------------- | -------- | -------------------------------------------------- |
+| `FIAP_USERNAME`       | Scraper  | FIAP course login                                  |
+| `FIAP_PASSWORD`       | Scraper  | FIAP course password                               |
+| `NOTION_TOKEN`        | Scraper  | Notion integration token                           |
+| `NOTION_PHASES_DB_ID` | Scraper  | Page ID of the top-level Fases database            |
+| `FFMPEG_CONCURRENCY`  | No       | Max parallel ffmpeg processes (default: unlimited) |
+
 ## Output
 
 All output is stored in `data/` (gitignored):

--- a/README.md
+++ b/README.md
@@ -1,55 +1,79 @@
-# FIAP to Notion Web Scraper
+# FIAP to Notion
 
 A work in progress... :hourglass_flowing_sand:
 
 ## Description
 
-This project automates syncing study materials from my FIAP course into my personal Notion workspace. It scrapes the course platform, extracts course structure and HLS video URLs, and persists everything locally — ready for upload to Notion.
+This project automates syncing study materials from my FIAP course into my personal Notion workspace. It has two modes:
 
-The scraper will:
+**Scraper** — authenticates on the FIAP platform, extracts course structure (phases, subjects, classes), matches each class to its Notion page, and scrapes HLS video URLs.
 
-1. Authenticate on the FIAP course page.
-2. Present an interactive phase selector with sync and video status indicators.
-3. Scrape subjects and classes for the selected phase, matching each to its Notion page.
-4. Extract HLS video URLs for each class, persisting progress to `output/output.json` after every class so runs are resumable on crash or CloudFront block.
-5. _(Upcoming)_ Upload videos to Notion.
+**Video Converter** — downloads HLS video streams and converts them to MP4 files using ffmpeg. Fully offline — no browser or credentials needed, just the scraped data.
+
+Both modes are fully resumable. Progress is persisted after every video/class, so interrupted runs pick up where they left off.
+
+### Flow
+
+1. Launch the CLI (`npm run dev`) and pick a mode: **Scraper** or **Video Converter**.
+2. **Scraper**: authenticate → select a phase → sync subjects/classes to Notion → fetch HLS video URLs.
+3. **Video Converter**: select a phase with fetched videos → download and convert all videos to MP4 in parallel.
+4. _(Upcoming)_ Upload videos to Notion.
 
 ## How It Works
 
 ```mermaid
 sequenceDiagram
     actor user as User
-    participant scraper as Scraper
-    participant state as output.json
+    participant cli as CLI
+    participant state as data/output.json
     participant fiap as FIAP Platform
     participant notion as Notion
+    participant ffmpeg as ffmpeg
 
-    user->>scraper: npm run dev
-    scraper->>fiap: Login + fetch phases
-    fiap-->>scraper: Phase list
-    scraper->>state: Load local data (last sync timestamp)
-    state-->>scraper: Synced phases + video status
+    user->>cli: npm run dev
+    cli->>user: Select mode
 
-    loop Until exit
-        scraper->>user: Select phase [S][V] status indicators
-        user-->>scraper: Fase N + action
+    rect rgb(40, 40, 60)
+        Note over cli,notion: Scraper Mode
+        cli->>fiap: Login + fetch phases
+        fiap-->>cli: Phase list
+        cli->>state: Load local data
+        state-->>cli: Synced phases + video status
 
-        opt Sync (first run only)
-            scraper->>fiap: Scrape subjects + classes
-            fiap-->>scraper: ClassItem[]
-            scraper->>notion: Query Conteúdo DB
-            notion-->>scraper: Existing entries
-            scraper->>scraper: Match titles → page IDs
-            scraper->>state: Upsert phase (preserve existing videos)
-        end
+        loop Until exit
+            cli->>user: Select phase [S][V]
+            user-->>cli: Fase N + action
 
-        opt Get Videos
-            loop Each unfetched class (sequential)
-                scraper->>fiap: Navigate to class content page (new tab)
-                fiap-->>scraper: Playlist items + thumbnail URLs
-                scraper->>scraper: Derive HLS URLs from CDN hash
-                scraper->>state: Write class videos immediately
+            opt Sync
+                cli->>fiap: Scrape subjects + classes
+                cli->>notion: Match to Conteúdo DB
+                cli->>state: Upsert phase
             end
+
+            opt Get Videos
+                loop Each unfetched class (sequential)
+                    cli->>fiap: Scrape HLS URLs (new tab)
+                    cli->>state: Write videos immediately
+                end
+            end
+        end
+    end
+
+    rect rgb(40, 60, 40)
+        Note over cli,ffmpeg: Video Converter Mode (offline)
+        cli->>state: Read phases with fetched videos
+
+        loop Until exit
+            cli->>user: Select phase [C]
+            user-->>cli: Fase N
+
+            par Download all unconverted videos
+                cli->>ffmpeg: HLS → MP4 (video 1)
+                cli->>ffmpeg: HLS → MP4 (video 2)
+                cli->>ffmpeg: HLS → MP4 (video N)
+            end
+            ffmpeg-->>cli: Done
+            cli->>state: Mark each video converted
         end
     end
 ```
@@ -69,6 +93,7 @@ graph TD
 ```
 
 Each **Fase** page contains two inline databases:
+
 - **Disciplinas** — one row per subject, with a relation to Conteúdo
 - **Conteúdo** — one row per class; this is what the scraper matches against and uploads to
 
@@ -77,6 +102,7 @@ Each **Fase** page contains two inline databases:
 - **[TypeScript](https://www.typescriptlang.org/)** — type-safe JavaScript
 - **[Puppeteer](https://pptr.dev/)** — headless browser for scraping the FIAP course platform
 - **[Notion SDK](https://github.com/makenotion/notion-sdk-js)** — querying and updating the Notion workspace
+- **[ffmpeg](https://ffmpeg.org/)** — HLS to MP4 video conversion (system install, not bundled)
 - **[@inquirer/prompts](https://github.com/SBoudrias/Inquirer.js)** — interactive CLI prompts
 - **[ora](https://github.com/sindresorhus/ora)** — terminal spinners for async feedback
 
@@ -86,6 +112,15 @@ Make sure you have the following installed:
 
 - **Node.js** (>= 24.x)
 - **npm** (>= 11.x)
+- **ffmpeg** — required for Video Converter mode
+
+```bash
+# Ubuntu/Debian
+sudo apt install ffmpeg
+
+# macOS
+brew install ffmpeg
+```
 
 **Tip**: It is highly recommended to use **[nvm](https://github.com/nvm-sh/nvm)** (Node Version Manager) to manage and switch between different versions of Node.js easily.
 
@@ -99,6 +134,21 @@ cd fiap-to-notion
 nvm use # If you have nvm it will set the projects node version for you
 npm install
 cp .env.example .env
+```
+
+## Output
+
+All output is stored in `data/` (gitignored):
+
+```
+data/
+├── output.json                              # Scraped state (phases, classes, video URLs, flags)
+└── videos/
+    └── Fase 1 - .../
+        └── Subject Name/
+            └── Class Name/
+                ├── Video Title - I.mp4
+                └── Video Title - II.mp4
 ```
 
 ## Scripts

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,12 +1,13 @@
 import { select, Separator } from '@inquirer/prompts';
 import { Phase } from '../phases/types';
 import { getPhaseDisplayTitle } from '../phases';
+import { StatePhase } from '../state/types';
+
+export type AppMode = 'scraper' | 'converter' | 'exit';
 
 export type PhaseAction = 'sync' | 'get-videos' | 'go-back' | 'exit';
 
-export type PhaseSelectionResult =
-  | { type: 'phase'; phase: Phase }
-  | { type: 'exit' };
+export type PhaseSelectionResult = { type: 'phase'; phase: Phase } | { type: 'exit' };
 
 /**
  * Prompts the user to choose an action after a phase is selected.
@@ -17,12 +18,17 @@ const VIDEO_ACTION_LABEL: Record<'~' | ' ', string> = {
   ' ': 'Get Videos',
 };
 
-export async function selectPhaseAction(isSynced: boolean, videoStatus: '~' | ' '): Promise<PhaseAction> {
+export async function selectPhaseAction(
+  isSynced: boolean,
+  videoStatus: '~' | ' ',
+): Promise<PhaseAction> {
   return select<PhaseAction>({
     message: 'What would you like to do?',
     choices: [
       ...(!isSynced ? [{ name: 'Sync', value: 'sync' as PhaseAction }] : []),
-      ...(isSynced ? [{ name: VIDEO_ACTION_LABEL[videoStatus], value: 'get-videos' as PhaseAction }] : []),
+      ...(isSynced
+        ? [{ name: VIDEO_ACTION_LABEL[videoStatus], value: 'get-videos' as PhaseAction }]
+        : []),
       { name: 'Go back', value: 'go-back' },
       new Separator(),
       { name: 'Exit', value: 'exit' },
@@ -48,9 +54,9 @@ export async function selectPhase(
     message: 'Select a phase:',
     choices: [
       ...phases.map((phase) => {
-        const synced = syncedPhaseTitles.has(phase.title);
-        const videoMark = phaseVideoStatus.get(phase.title) ?? ' ';
         const label = getPhaseDisplayTitle(phase);
+        const synced = syncedPhaseTitles.has(label);
+        const videoMark = phaseVideoStatus.get(label) ?? ' ';
         const suffix = phase.isActive ? ' (active)' : '';
         const done = synced && videoMark === '✓';
         return {
@@ -67,4 +73,73 @@ export async function selectPhase(
 
   if (result === 'exit') return { type: 'exit' };
   return { type: 'phase', phase: result };
+}
+
+// --- Top-level mode selector ---
+
+export async function selectMode(hasScrapedData: boolean): Promise<AppMode> {
+  return select<AppMode>({
+    message: 'What would you like to do?',
+    choices: [
+      { name: 'Scraper', value: 'scraper' },
+      { name: 'Video Converter', value: 'converter', disabled: !hasScrapedData },
+      new Separator(),
+      { name: 'Exit', value: 'exit' },
+    ],
+  });
+}
+
+// --- Converter CLI ---
+
+export type ConverterPhaseResult = { type: 'phase'; phase: StatePhase } | { type: 'exit' };
+
+export type ConverterAction = 'convert-videos' | 'go-back' | 'exit';
+
+/**
+ * Prompts the user to select a phase for video conversion.
+ * Only phases with fetched videos appear. Fully converted phases are disabled.
+ */
+export async function selectConverterPhase(
+  phases: StatePhase[],
+  conversionStatus: Map<string, '✓' | '~' | ' '>,
+): Promise<ConverterPhaseResult> {
+  type Choice = StatePhase | 'exit';
+
+  console.log('  [C]  C = Converted (✓ all · ~ partial)');
+  const result = await select<Choice>({
+    message: 'Select a phase to convert:',
+    choices: [
+      ...phases.map((phase) => {
+        const mark = conversionStatus.get(phase.title) ?? ' ';
+        const done = mark === '✓';
+        return {
+          name: `[${mark}] ${phase.title}`,
+          value: phase as Choice,
+          disabled: done,
+        };
+      }),
+      new Separator(),
+      { name: 'Exit', value: 'exit' as Choice },
+    ],
+  });
+
+  if (result === 'exit') return { type: 'exit' };
+  return { type: 'phase', phase: result };
+}
+
+const CONVERT_ACTION_LABEL: Record<'~' | ' ', string> = {
+  '~': 'Continue converting videos',
+  ' ': 'Convert Videos',
+};
+
+export async function selectConverterAction(conversionStatus: '~' | ' '): Promise<ConverterAction> {
+  return select<ConverterAction>({
+    message: 'What would you like to do?',
+    choices: [
+      { name: CONVERT_ACTION_LABEL[conversionStatus], value: 'convert-videos' },
+      { name: 'Go back', value: 'go-back' },
+      new Separator(),
+      { name: 'Exit', value: 'exit' },
+    ],
+  });
 }

--- a/src/content-video/index.ts
+++ b/src/content-video/index.ts
@@ -23,10 +23,13 @@ async function scrapeClassVideos(page: Page, contentUrl: string): Promise<Conten
   await assertNotBlocked(page);
 
   // The iframe loads asynchronously — wait until .pos_videos_container is present inside it
-  await page.waitForFunction(() => {
-    const iframe = document.querySelector('#iframecontent') as HTMLIFrameElement | null;
-    return !!iframe?.contentDocument?.querySelector('.pos_videos_container');
-  }, { timeout: TIMEOUT_MS });
+  await page.waitForFunction(
+    () => {
+      const iframe = document.querySelector('#iframecontent') as HTMLIFrameElement | null;
+      return !!iframe?.contentDocument?.querySelector('.pos_videos_container');
+    },
+    { timeout: TIMEOUT_MS },
+  );
 
   const rawVideos = await page.evaluate(() => {
     const iframe = document.querySelector('#iframecontent') as HTMLIFrameElement | null;
@@ -37,7 +40,8 @@ async function scrapeClassVideos(page: Page, contentUrl: string): Promise<Conten
       title: item.querySelector('.pos-playlist-item-title')?.textContent?.trim() ?? '',
       duration: item.querySelector('.pos-playlist-duration')?.textContent?.trim() ?? '',
       // .src gives the absolute URL; used to derive the HLS URL via the shared CDN hash
-      thumbnailUrl: (item.querySelector('.pos-playlist-image-thumbnail') as HTMLImageElement | null)?.src ?? '',
+      thumbnailUrl:
+        (item.querySelector('.pos-playlist-image-thumbnail') as HTMLImageElement | null)?.src ?? '',
     }));
   });
 
@@ -47,6 +51,7 @@ async function scrapeClassVideos(page: Page, contentUrl: string): Promise<Conten
       title: v.title,
       duration: v.duration,
       hlsUrl: hlsUrlFromThumbnail(v.thumbnailUrl),
+      converted: false,
     }));
 }
 

--- a/src/content-video/types.ts
+++ b/src/content-video/types.ts
@@ -2,4 +2,5 @@ export interface ContentVideo {
   title: string;
   duration: string;
   hlsUrl: string;
+  converted: boolean;
 }

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -132,7 +132,17 @@ export async function convertPhaseVideos(
     ),
   );
 
-  await Promise.all(tasks.map((task) => task()));
+  const concurrency = process.env.FFMPEG_CONCURRENCY
+    ? parseInt(process.env.FFMPEG_CONCURRENCY, 10)
+    : 0;
+
+  if (concurrency > 0) {
+    for (let i = 0; i < tasks.length; i += concurrency) {
+      await Promise.all(tasks.slice(i, i + concurrency).map((task) => task()));
+    }
+  } else {
+    await Promise.all(tasks.map((task) => task()));
+  }
 
   return tasks.length;
 }

--- a/src/download/index.ts
+++ b/src/download/index.ts
@@ -1,0 +1,138 @@
+import { execSync, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { StateSubject } from '../state/types';
+
+const VIDEOS_DIR = path.join(process.cwd(), 'data', 'videos');
+
+/**
+ * Validates that ffmpeg is available on PATH.
+ * Call once at the start of converter flow — fails fast with a clear message.
+ */
+export function assertFfmpegAvailable(): void {
+  try {
+    execSync('ffmpeg -version', { stdio: 'ignore' });
+  } catch {
+    throw new Error(
+      'ffmpeg is not installed or not on PATH. Install it (e.g. `sudo apt install ffmpeg` or `brew install ffmpeg`) and try again.',
+    );
+  }
+}
+
+/** Replaces filesystem-unsafe characters with underscores and trims whitespace. */
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[/\\:*?"<>|]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Returns the absolute path where a converted video should be stored. */
+export function getVideoOutputPath(
+  phaseTitle: string,
+  subjectTitle: string,
+  classTitle: string,
+  videoTitle: string,
+): string {
+  return path.join(
+    VIDEOS_DIR,
+    sanitizeFilename(phaseTitle),
+    sanitizeFilename(subjectTitle),
+    sanitizeFilename(classTitle),
+    `${sanitizeFilename(videoTitle)}.mp4`,
+  );
+}
+
+/**
+ * Parses ffmpeg's `time=HH:MM:SS.xx` progress token from a stderr chunk.
+ * Returns the timestamp string or null if not found.
+ */
+function parseTimeProgress(chunk: string): string | null {
+  const match = chunk.match(/time=(\d{2}:\d{2}:\d{2}\.\d{2})/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Downloads an HLS stream and remuxes it to MP4 via ffmpeg.
+ * Uses `-c copy` (no re-encoding) and `-movflags +faststart` for streaming-friendly output.
+ * `-y` overwrites partial files from interrupted previous runs.
+ */
+function downloadVideo(
+  hlsUrl: string,
+  outputPath: string,
+  onProgress?: (time: string) => void,
+): Promise<void> {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      'ffmpeg',
+      ['-y', '-i', hlsUrl, '-c', 'copy', '-movflags', '+faststart', outputPath],
+      {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      },
+    );
+
+    let stderr = '';
+    proc.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      const time = parseTimeProgress(text);
+      if (time) onProgress?.(time);
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg exited with code ${code}:\n${stderr.slice(-500)}`));
+      }
+    });
+
+    proc.on('error', reject);
+  });
+}
+
+export interface ConvertVideoResult {
+  classTitle: string;
+  videoTitle: string;
+}
+
+export interface ConvertProgress {
+  videoTitle: string;
+  /** Current position in HH:MM:SS.xx format */
+  time: string;
+}
+
+/**
+ * Downloads all unconverted videos for a phase in parallel.
+ * Since `-c copy` only does network I/O and remuxing, parallelism is bounded by bandwidth, not CPU.
+ */
+export async function convertPhaseVideos(
+  phaseTitle: string,
+  subjects: StateSubject[],
+  options?: {
+    onVideoDone?: (result: ConvertVideoResult) => void;
+    onProgress?: (progress: ConvertProgress) => void;
+  },
+): Promise<number> {
+  const { onVideoDone, onProgress } = options ?? {};
+
+  const tasks = subjects.flatMap((subject) =>
+    subject.classes.flatMap((cls) =>
+      cls.videos
+        .filter((video) => !video.converted)
+        .map((video) => async () => {
+          const outputPath = getVideoOutputPath(phaseTitle, subject.title, cls.title, video.title);
+          await downloadVideo(video.hlsUrl, outputPath, (time) =>
+            onProgress?.({ videoTitle: video.title, time }),
+          );
+          onVideoDone?.({ classTitle: cls.title, videoTitle: video.title });
+        }),
+    ),
+  );
+
+  await Promise.all(tasks.map((task) => task()));
+
+  return tasks.length;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,49 @@
 import 'dotenv/config';
 import ora from 'ora';
-import puppeteer from 'puppeteer';
+import puppeteer, { Browser } from 'puppeteer';
 import { Client } from '@notionhq/client';
 import { loginToFIAP, ensureAccessToCoursePage } from './auth';
 import { getPhaseList, getPhaseDisplayTitle } from './phases';
 import { getSubjectList } from './subjects';
 import { getPhaseCollections, matchClassesToNotion } from './notion';
-import { selectPhase, selectPhaseAction } from './cli';
+import {
+  selectMode,
+  selectPhase,
+  selectPhaseAction,
+  selectConverterPhase,
+  selectConverterAction,
+} from './cli';
 import { getAllVideos } from './content-video';
-import { hasLocalData, readOutput, writeOutput, upsertPhase, setPhaseVideos } from './state';
+import {
+  hasLocalData,
+  readOutput,
+  writeOutput,
+  upsertPhase,
+  setPhaseVideos,
+  setVideoConverted,
+} from './state';
+import { assertFfmpegAvailable, convertPhaseVideos } from './download';
 
-async function main() {
+function validateScraperEnv(): void {
   if (!process.env.FIAP_USERNAME || !process.env.FIAP_PASSWORD) {
     throw new Error('Please provide FIAP_USERNAME and FIAP_PASSWORD in .env file');
   }
   if (!process.env.NOTION_TOKEN || !process.env.NOTION_PHASES_DB_ID) {
     throw new Error('Please provide NOTION_TOKEN and NOTION_PHASES_DB_ID in .env file');
   }
+}
 
-  const browser = await puppeteer.launch({ headless: false });
+async function runScraper(): Promise<void> {
+  validateScraperEnv();
+
+  const browser: Browser = await puppeteer.launch({ headless: true });
 
   try {
     let spinner = ora('[scraper] Logging in to FIAP...').start();
     const page = await browser.newPage();
     await loginToFIAP(page, {
-      username: process.env.FIAP_USERNAME,
-      password: process.env.FIAP_PASSWORD,
+      username: process.env.FIAP_USERNAME!,
+      password: process.env.FIAP_PASSWORD!,
     });
     spinner.succeed('[scraper] Logged in');
 
@@ -39,7 +57,9 @@ async function main() {
 
     if (hasLocalData()) {
       const { lastUpdated } = readOutput();
-      console.log(`\nℹ️  Local scraping data found (last synced: ${new Date(lastUpdated).toLocaleString()})`);
+      console.log(
+        `\nℹ️  Local scraping data found (last synced: ${new Date(lastUpdated).toLocaleString()})`,
+      );
     }
 
     const notion = new Client({ auth: process.env.NOTION_TOKEN });
@@ -62,11 +82,10 @@ async function main() {
 
       const { phase: selectedPhase } = selection;
       const displayTitle = getPhaseDisplayTitle(selectedPhase);
-      const isSynced = syncedPhaseTitles.has(selectedPhase.title);
-      // '✓' phases are disabled in the selector so only '~' or ' ' reach here
-      const videoStatus = (phaseVideoStatus.get(selectedPhase.title) ?? ' ') as '~' | ' ';
+      const isSynced = syncedPhaseTitles.has(displayTitle);
+      const videoStatus = (phaseVideoStatus.get(displayTitle) ?? ' ') as '~' | ' ';
 
-      let action = await selectPhaseAction(isSynced, videoStatus);
+      const action = await selectPhaseAction(isSynced, videoStatus);
       if (action === 'go-back') continue;
       if (action === 'exit') break;
 
@@ -88,12 +107,11 @@ async function main() {
         }
 
         writeOutput(upsertPhase(readOutput(), selectedPhase, subjects, classMap));
-        spinner.succeed(`[scraper] Saved phase data to output/output.json`);
+        spinner.succeed(`[scraper] Saved phase data to data/output.json`);
       }
 
       if (action === 'get-videos') {
-        // Re-read from output, skipping classes already fully fetched
-        const phaseData = readOutput().phases.find((p) => p.title === selectedPhase.title)!;
+        const phaseData = readOutput().phases.find((p) => p.title === displayTitle)!;
         const subjects = phaseData.subjects.map((s) => ({
           title: s.title,
           classes: s.classes
@@ -110,8 +128,6 @@ async function main() {
           .flatMap((s) => s.classes)
           .filter((c) => c.contentUrl !== null).length;
         let fetchedCount = 0;
-        // Read once upfront; onClassDone updates this local copy and writes it,
-        // avoiding redundant disk reads on every class completion
         let currentOutput = readOutput();
         spinner = ora(`[scraper] Fetching videos... (0/${classesWithUrlCount} classes)`).start();
         let classVideos;
@@ -119,12 +135,14 @@ async function main() {
           classVideos = await getAllVideos(page, subjects, {
             onClassDone: ({ classTitle, videos }) => {
               spinner.text = `[scraper] Fetching videos... (${++fetchedCount}/${classesWithUrlCount} classes)`;
-              currentOutput = setPhaseVideos(currentOutput, selectedPhase.title, [{ classTitle, videos }]);
+              currentOutput = setPhaseVideos(currentOutput, displayTitle, [{ classTitle, videos }]);
               writeOutput(currentOutput);
             },
           });
         } catch (err) {
-          spinner.fail(`[scraper] Fetching videos interrupted (${fetchedCount}/${classesWithUrlCount} classes)`);
+          spinner.fail(
+            `[scraper] Fetching videos interrupted (${fetchedCount}/${classesWithUrlCount} classes)`,
+          );
           throw err;
         }
 
@@ -132,12 +150,108 @@ async function main() {
         if (totalVideos === 0) {
           spinner.warn('\n⚠️  [scraper] No videos found');
         } else {
-          spinner.succeed(`[scraper] Found ${totalVideos} videos across ${classVideos.length} classes, saved to output/output.json`);
+          spinner.succeed(
+            `[scraper] Found ${totalVideos} videos across ${classVideos.length} classes, saved to data/output.json`,
+          );
         }
       }
     }
   } finally {
     await browser.close();
+  }
+}
+
+function getConversionStatus(
+  phases: { title: string; subjects: { classes: { videos: { converted: boolean }[] }[] }[] }[],
+): Map<string, '✓' | '~' | ' '> {
+  return new Map(
+    phases.map((p) => {
+      const allVideos = p.subjects.flatMap((s) => s.classes.flatMap((c) => c.videos));
+      if (allVideos.length === 0) return [p.title, ' ' as const];
+      const convertedCount = allVideos.filter((v) => v.converted).length;
+      const mark = convertedCount === 0 ? ' ' : convertedCount === allVideos.length ? '✓' : '~';
+      return [p.title, mark as '✓' | '~' | ' '];
+    }),
+  );
+}
+
+async function runConverter(): Promise<void> {
+  assertFfmpegAvailable();
+
+  while (true) {
+    console.log();
+    const output = readOutput();
+
+    // Only show phases that have videos fetched
+    const eligiblePhases = output.phases.filter((p) =>
+      p.subjects.some((s) => s.classes.some((c) => c.videosFetched && c.videos.length > 0)),
+    );
+
+    if (eligiblePhases.length === 0) {
+      console.log('⚠️  No phases with fetched videos. Run the Scraper first to fetch video URLs.');
+      return;
+    }
+
+    const conversionStatus = getConversionStatus(eligiblePhases);
+    const selection = await selectConverterPhase(eligiblePhases, conversionStatus);
+
+    if (selection.type === 'exit') break;
+
+    const { phase: selectedPhase } = selection;
+    const status = (conversionStatus.get(selectedPhase.title) ?? ' ') as '~' | ' ';
+
+    const action = await selectConverterAction(status);
+    if (action === 'go-back') continue;
+    if (action === 'exit') break;
+
+    console.log();
+
+    const allVideos = selectedPhase.subjects.flatMap((s) => s.classes.flatMap((c) => c.videos));
+    const totalVideos = allVideos.length;
+    let convertedCount = allVideos.filter((v) => v.converted).length;
+
+    let currentOutput = readOutput();
+    const spinner = ora(`[converter] (${convertedCount}/${totalVideos}) Starting...`).start();
+
+    try {
+      await convertPhaseVideos(selectedPhase.title, selectedPhase.subjects, {
+        onProgress: ({ videoTitle, time }) => {
+          spinner.text = `[converter] (${convertedCount}/${totalVideos}) ${videoTitle} — ${time}`;
+        },
+        onVideoDone: ({ classTitle, videoTitle }) => {
+          convertedCount++;
+          // Log completed video above the spinner
+          spinner.clear();
+          console.log(`  ✓ ${videoTitle}`);
+          spinner.text = `[converter] (${convertedCount}/${totalVideos}) Downloading...`;
+          spinner.render();
+
+          currentOutput = setVideoConverted(
+            currentOutput,
+            selectedPhase.title,
+            classTitle,
+            videoTitle,
+          );
+          writeOutput(currentOutput);
+        },
+      });
+    } catch (err) {
+      spinner.fail(`[converter] Conversion interrupted (${convertedCount}/${totalVideos})`);
+      throw err;
+    }
+
+    spinner.succeed(`[converter] All videos converted (${convertedCount}/${totalVideos})`);
+  }
+}
+
+async function main() {
+  while (true) {
+    console.log();
+    const mode = await selectMode(hasLocalData());
+
+    if (mode === 'exit') break;
+    if (mode === 'scraper') await runScraper();
+    if (mode === 'converter') await runConverter();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   setPhaseVideos,
   setVideoConverted,
 } from './state';
+import { StatePhase } from './state/types';
 import { assertFfmpegAvailable, convertPhaseVideos } from './download';
 
 function validateScraperEnv(): void {
@@ -161,9 +162,7 @@ async function runScraper(): Promise<void> {
   }
 }
 
-function getConversionStatus(
-  phases: { title: string; subjects: { classes: { videos: { converted: boolean }[] }[] }[] }[],
-): Map<string, '✓' | '~' | ' '> {
+function getConversionStatus(phases: StatePhase[]): Map<string, '✓' | '~' | ' '> {
   return new Map(
     phases.map((p) => {
       const allVideos = p.subjects.flatMap((s) => s.classes.flatMap((c) => c.videos));

--- a/src/notion/index.ts
+++ b/src/notion/index.ts
@@ -66,9 +66,7 @@ export async function getPhaseCollections(
         block.type === 'child_database' && block.child_database.title === 'Conteúdo',
     );
     blockCursor =
-      !conteudoBlock && blocks.has_more && blocks.next_cursor
-        ? blocks.next_cursor
-        : undefined;
+      !conteudoBlock && blocks.has_more && blocks.next_cursor ? blocks.next_cursor : undefined;
   } while (!conteudoBlock && blockCursor);
 
   if (!conteudoBlock) {

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { Phase } from '../phases/types';
+import { getPhaseDisplayTitle } from '../phases';
 import { Subject } from '../subjects/types';
 import { ClassNotionMap } from '../notion/types';
 import { ContentVideo } from '../content-video/types';
@@ -22,7 +23,10 @@ export function readOutput(): ScraperOutput {
 
 export function writeOutput(output: ScraperOutput): void {
   fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-  fs.writeFileSync(OUTPUT_FILE, JSON.stringify({ ...output, lastUpdated: new Date().toISOString() }, null, 2));
+  fs.writeFileSync(
+    OUTPUT_FILE,
+    JSON.stringify({ ...output, lastUpdated: new Date().toISOString() }, null, 2),
+  );
 }
 
 export function clearOutput(): void {
@@ -39,10 +43,11 @@ export function upsertPhase(
   subjects: Subject[],
   classMap: ClassNotionMap,
 ): ScraperOutput {
-  const existingPhase = output.phases.find((p) => p.title === phase.title);
+  const displayTitle = getPhaseDisplayTitle(phase);
+  const existingPhase = output.phases.find((p) => p.title === displayTitle);
 
   const updatedPhase: StatePhase = {
-    title: phase.title,
+    title: displayTitle,
     subjects: subjects.map((subject) => ({
       title: subject.title,
       classes: subject.classes.map((classItem) => {
@@ -65,10 +70,42 @@ export function upsertPhase(
   };
 
   const phases = existingPhase
-    ? output.phases.map((p) => (p.title === phase.title ? updatedPhase : p))
+    ? output.phases.map((p) => (p.title === displayTitle ? updatedPhase : p))
     : [...output.phases, updatedPhase];
 
   return { ...output, phases };
+}
+
+/**
+ * Marks a specific video as converted within a phase.
+ */
+export function setVideoConverted(
+  output: ScraperOutput,
+  phaseTitle: string,
+  classTitle: string,
+  videoTitle: string,
+): ScraperOutput {
+  return {
+    ...output,
+    phases: output.phases.map((phase) => {
+      if (phase.title !== phaseTitle) return phase;
+      return {
+        ...phase,
+        subjects: phase.subjects.map((subject) => ({
+          ...subject,
+          classes: subject.classes.map((cls) => {
+            if (cls.title !== classTitle) return cls;
+            return {
+              ...cls,
+              videos: cls.videos.map((v) =>
+                v.title === videoTitle ? { ...v, converted: true } : v,
+              ),
+            };
+          }),
+        })),
+      };
+    }),
+  };
 }
 
 /**
@@ -91,9 +128,7 @@ export function setPhaseVideos(
           ...subject,
           classes: subject.classes.map((cls) => {
             const videos = videosByClass.get(cls.title);
-            return videos !== undefined
-              ? { ...cls, videos, videosFetched: true }
-              : cls;
+            return videos !== undefined ? { ...cls, videos, videosFetched: true } : cls;
           }),
         })),
       };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,8 +11,6 @@ export async function assertNotBlocked(page: Page): Promise<void> {
     document.body?.textContent?.includes('The request could not be satisfied'),
   );
   if (isBlocked) {
-    throw new Error(
-      `CloudFront blocked the request for ${page.url()} — stop and retry later.`,
-    );
+    throw new Error(`CloudFront blocked the request for ${page.url()} — stop and retry later.`);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src", 
+    "baseUrl": "./src",
     "target": "ES6",
     "module": "commonjs",
     "strict": true,


### PR DESCRIPTION
## Summary

- Add **Video Converter** mode that downloads scraped HLS streams and remuxes them to MP4 via system ffmpeg — fully offline, no browser needed
- New top-level CLI menu (Scraper / Video Converter) with converter disabled when no scraped data exists
- Downloads run in **parallel** (`Promise.all`), with per-video `converted` flag for resumable runs
- Videos stored at `data/videos/<phase>/<subject>/<class>/<video>.mp4`
- Updated CLAUDE.md and README with new architecture, ffmpeg prerequisite, and output structure

Closes #9

## Test plan

- [x] `npm run dev` → Scraper mode works unchanged (sync + get videos)
- [x] `npm run dev` → Video Converter disabled when no `data/output.json`
- [x] Video Converter → select phase → downloads videos in parallel with progress spinner
- [x] Interrupt mid-conversion → re-run picks up unconverted videos
- [x] Fully converted phase shows as disabled in converter selector
- [x] Without ffmpeg on PATH → clear error message at converter startup



<img width="974" height="834" alt="image" src="https://github.com/user-attachments/assets/c9926346-b919-482b-bf2c-5c08aa0f3e1f" />
